### PR TITLE
Add and delete tasks / groups with persistent storage.

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1144,7 +1144,6 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
- "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = "0.31.0"
 lazy_static = "1.4.0"
-uuid = "1.8.0"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -173,6 +173,8 @@ pub mod ops {
             Ok(())
         }
 
+        // TODO: get_final_structure() is recursive, an iterative alternative exists.
+
         /// Forms the nested root TaskGroup containing all tasks/groups expected by frontend.
         /// Uses DFS traversal.
         fn get_final_structure(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,9 +22,10 @@ fn main() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            ops::commands::get_tasks_view,
             ops::commands::add_task,
             ops::commands::add_task_group,
-            ops::commands::get_tasks_view
+            ops::commands::delete_task,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,7 @@
 
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 
-use habtrack::db::{init::DbInitializer, ops};
+use habtrack::db::{init::DbInitializer, ops, DB_SINGLETON};
 
 // Start work on database.
 // TODO: Once done, merge with main, and pull changes into FEATURE-add-delete-task.
@@ -11,14 +11,20 @@ use habtrack::db::{init::DbInitializer, ops};
 fn main() {
     tauri::Builder::default()
         .setup(|app| {
-            DbInitializer::new(app.handle()).init();
+            let db_init_obj = DbInitializer::new(app.handle()).init();
+            println!("calling set_conn now");
+            DB_SINGLETON
+                .lock()
+                .unwrap()
+                .set_conn(db_init_obj.get_db_path().as_str())
+                .expect("i fucked up");
 
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            ops::add_task,
-            ops::add_task_group,
-            ops::get_tasks_view
+            ops::commands::add_task,
+            ops::commands::add_task_group,
+            ops::commands::get_tasks_view
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,6 @@ fn main() {
     tauri::Builder::default()
         .setup(|app| {
             let db_init_obj = DbInitializer::new(app.handle()).init();
-            println!("calling set_conn now");
             DB_SINGLETON
                 .lock()
                 .unwrap()

--- a/src/App.css
+++ b/src/App.css
@@ -93,6 +93,7 @@ p {
   justify-content: center;
   align-items: center;
   color: var(--light);
+  z-index: 1;
 }
 
 .container {
@@ -129,6 +130,7 @@ p {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  z-index: 0;
 }
 
 .sidebar-list .row {
@@ -194,6 +196,45 @@ p {
 }
 
 /* -------------------------------------------------------------------------- */
+/* ------------------------------MODAL STYLES-------------------------------- */
+/* -------------------------------------------------------------------------- */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal {
+  background: var(--secondary);
+  padding: 20px;
+  border-radius: 10px;
+  width: 400px;
+  max-width: 80%;
+}
+
+.form-group {
+  margin-bottom: 15px;
+}
+
+.option-buttons button {
+  margin: 0 5px;
+}
+
+.option-buttons .active {
+  background-color: #007bff;
+  color: white;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: space-between;
+}
+
+/* -------------------------------------------------------------------------- */
 /* -----------------------------TASK VIEW STYLES----------------------------- */
 /* -------------------------------------------------------------------------- */
 
@@ -235,6 +276,7 @@ p {
   /* height: fit-content; */
   height: inherit;
   background-color: var(--grey);
+  border: 1px solid black;
   border-radius: 1rem;
   box-shadow: 0px 10px 8px rgb(0, 0, 0);
 

--- a/src/App.css
+++ b/src/App.css
@@ -75,6 +75,12 @@ p {
   align-self: center;
 }
 
+ul {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 /* -------------------------------------------------------------------------- */
 /* ------------------------TOP-MOST LEVEL STYLING---------------------------- */
 /* -------------------------------------------------------------------------- */
@@ -335,6 +341,7 @@ p {
   /* height: fit-content; */
   height: inherit;
   min-width: 500px;
+  max-width: 750px;
 
   background-color: var(--primary);
   border: 1px solid black;
@@ -377,33 +384,13 @@ p {
   box-shadow: inset 2px 2px 10px #000;
 }
 
-.task-btn {
-  background: #3576bb;
+.delete-icon, .edit-icon {
   color: white;
+  background-color: #3576bb;
   border: none;
-  padding: 12px;
-  font-family: CustFont, sans-serif;
-  font-size: 1.05rem;
-  cursor: pointer;
-  outline: inherit;
   border-radius: 17px;
   box-shadow: 6px 6px 7px #000;
-}
-
-.task-btn:hover {
-  filter: brightness(120%);
-  box-shadow: 10px 10px 10px #000;
-}
-
-.task-btn:active {
-  box-shadow: inset 2px 2px 10px #000;
-}
-
-.delete-icon {
-  color: white;
-  border: none;
   padding: 12px;
-  font-size: 24px;
   cursor: pointer;
 }
 
@@ -412,19 +399,12 @@ p {
   color: red;
   filter: brightness(120%);
   border-radius: 15px;
+  box-shadow: 10px 10px 10px #000;
 }
 
 .delete-icon:active {
   color: white;
   box-shadow: inset 2px 2px 10px white;
-}
-
-.edit-icon {
-  color: blue;
-  border: none;
-  padding: 12px;
-  font-size: 24px;
-  cursor: pointer;
 }
 
 .edit-icon:hover {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,14 +15,17 @@ import TasksView from "./views/TasksView/TasksView";
 import HabitsView from "./views/HabitsView/HabitsView";
 import StreaksWatchView from "./views/StreaksWatchView/StreaksWatchView";
 
+// Constants.
+import { TASKS_VIEW, HABITS_VIEW, STREAKS_VIEW } from "./Constants";
+
 const TABS = [
-  { id: "0", name: "Tasks", icon: <AssignmentIcon /> },
-  { id: "1", name: "Habits", icon: <DirectionsRunIcon /> },
-  { id: "2", name: "StreaksWatch", icon: <AutoGraphIcon /> },
+  { id: "0", name: TASKS_VIEW, icon: <AssignmentIcon /> },
+  { id: "1", name: HABITS_VIEW, icon: <DirectionsRunIcon /> },
+  { id: "2", name: STREAKS_VIEW, icon: <AutoGraphIcon /> },
 ];
 
 function App() {
-  const [tab, setTab] = useState("Tasks");
+  const [tab, setTab] = useState(TASKS_VIEW);
   const [showSidebar, setSidebar] = useState(true);
 
   function toggleTab(newTab) {
@@ -41,9 +44,9 @@ function App() {
           <Sidebar tabs={TABS} toggleTab={toggleTab} activeTab={tab} />
         )}
         <div className="main-area">
-          {tab === "Tasks" && <TasksView />}
-          {tab === "Habits" && <HabitsView />}
-          {tab === "StreaksWatch" && <StreaksWatchView />}
+          {tab === TASKS_VIEW && <TasksView />}
+          {tab === HABITS_VIEW && <HabitsView />}
+          {tab === STREAKS_VIEW && <StreaksWatchView />}
         </div>
       </div>
     </>

--- a/src/Constants.jsx
+++ b/src/Constants.jsx
@@ -13,6 +13,7 @@ const TASK_GROUP = "TaskGroup";
 const TAURI_FETCH_TASKS = "get_tasks_view";
 const TAURI_ADD_TASK = "add_task";
 const TAURI_ADD_TASKGROUP = "add_task_group";
+const TAURI_DELETE_TASK = "delete_task";
 
 export {
   // Table names
@@ -30,4 +31,5 @@ export {
   TAURI_FETCH_TASKS,
   TAURI_ADD_TASK,
   TAURI_ADD_TASKGROUP,
+  TAURI_DELETE_TASK,
 };

--- a/src/Constants.jsx
+++ b/src/Constants.jsx
@@ -1,10 +1,33 @@
-// Global.
+// Table names
+const TODAY = "today";
+
+// Frontend Global.
 const ROOT = "/";
+const TASKS_VIEW = "Tasks";
+const HABITS_VIEW = "Habits";
+const STREAKS_VIEW = "StreaksWatch";
 
 // TasksView.
 const TASK = "Task";
 const TASK_GROUP = "TaskGroup";
-const TASKS_VIEW = "view";
 const TAURI_FETCH_TASKS = "get_tasks_view";
+const TAURI_ADD_TASK = "add_task";
+const TAURI_ADD_TASKGROUP = "add_task_group";
 
-export { ROOT, TASK, TASK_GROUP, TASKS_VIEW, TAURI_FETCH_TASKS };
+export {
+  // Table names
+  TODAY,
+
+  // Frontend Global
+  ROOT,
+  TASKS_VIEW,
+  HABITS_VIEW,
+  STREAKS_VIEW,
+
+  // TasksView
+  TASK,
+  TASK_GROUP,
+  TAURI_FETCH_TASKS,
+  TAURI_ADD_TASK,
+  TAURI_ADD_TASKGROUP,
+};

--- a/src/Constants.jsx
+++ b/src/Constants.jsx
@@ -1,0 +1,10 @@
+// Global.
+const ROOT = "/";
+
+// TasksView.
+const TASK = "Task";
+const TASK_GROUP = "TaskGroup";
+const TASKS_VIEW = "view";
+const TAURI_FETCH_TASKS = "get_tasks_view";
+
+export { ROOT, TASK, TASK_GROUP, TASKS_VIEW, TAURI_FETCH_TASKS };

--- a/src/Constants.jsx
+++ b/src/Constants.jsx
@@ -10,7 +10,7 @@ const STREAKS_VIEW = "StreaksWatch";
 // TasksView.
 const TASK = "Task";
 const TASK_GROUP = "TaskGroup";
-const TAURI_FETCH_TASKS = "get_tasks_view";
+const TAURI_FETCH_TASKS_VIEW = "get_tasks_view";
 const TAURI_ADD_TASK = "add_task";
 const TAURI_ADD_TASKGROUP = "add_task_group";
 const TAURI_DELETE_TASK = "delete_task";
@@ -28,7 +28,7 @@ export {
   // TasksView
   TASK,
   TASK_GROUP,
-  TAURI_FETCH_TASKS,
+  TAURI_FETCH_TASKS_VIEW,
   TAURI_ADD_TASK,
   TAURI_ADD_TASKGROUP,
   TAURI_DELETE_TASK,

--- a/src/components/AddItemModal.jsx
+++ b/src/components/AddItemModal.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { useState } from "react";
+
+import CloseIcon from "@mui/icons-material/Close";
+
+// itempType is either TASK or HABIT.
+
+const AddItemModal = ({ itemType, onAdd, onCancel }) => {
+  const [option, setOption] = useState("Task");
+  const [name, setName] = useState("");
+  const [parentName, setParentName] = useState("");
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    console.log("inside handleSubmit");
+    onAdd(option, name, parentName);
+  }
+
+  function onClose() {
+    onCancel();
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div>
+        <button className="close-btn" onClick={onClose}>
+          <CloseIcon />
+        </button>
+        <div className="modal">
+          <h2>Add</h2>
+          <form onSubmit={handleSubmit}>
+            <div className="form-group">
+              <label>Options:</label>
+              <div className="option-buttons">
+                <button
+                  type="button"
+                  className={option === "Task" ? "active" : ""}
+                  onClick={() => setOption("Task")}
+                >
+                  Task
+                </button>
+                <button
+                  type="button"
+                  className={option === "TaskGroup" ? "active" : ""}
+                  onClick={() => setOption("TaskGroup")}
+                >
+                  Group
+                </button>
+              </div>
+            </div>
+            <div className="form-group">
+              <label>Name:</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div className="form-group">
+              <label>Parent Name:</label>
+              <input
+                type="text"
+                value={parentName}
+                onChange={(e) => setParentName(e.target.value)}
+              />
+            </div>
+            <div className="form-actions">
+              <button type="button" onClick={() => onClose()}>
+                Cancel
+              </button>
+              <button type="submit">Add</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AddItemModal;

--- a/src/components/AddItemModal.jsx
+++ b/src/components/AddItemModal.jsx
@@ -12,7 +12,6 @@ const AddItemModal = ({ itemType, onAdd, onCancel }) => {
 
   function handleSubmit(e) {
     e.preventDefault();
-    console.log("inside handleSubmit");
     onAdd(option, name, parentName);
   }
 

--- a/src/utility/AddRemoveItems.jsx
+++ b/src/utility/AddRemoveItems.jsx
@@ -1,0 +1,36 @@
+import { TASK, TASK_GROUP } from "../Constants";
+
+// Helper function to find the target group and add the item.
+const addItem = (item, targetId, node) => {
+  if (node.id === targetId) {
+    if (!node.children) node.children = [];
+    node.children.push(item);
+    // Sorting & reversing so that sub-tasks appear above sub-groups.
+    node.children.sort(tasksFirstGroupsNext);
+  } else if (node.children) {
+    // Find and add the item in the group in which it needs to be added.
+    node.children.forEach((child) => addItem(item, targetId, child));
+  }
+};
+
+// Helper function to find and remove the item from its original location.
+const removeItem = (id, node) => {
+  if (node.children) {
+    node.children = node.children.filter((child) => child.id !== id);
+    node.children.sort(tasksFirstGroupsNext)
+    // If item not found in node.children, search and remove it from each child of node.children.
+    node.children.forEach((child) => removeItem(id, child));
+  }
+};
+
+function tasksFirstGroupsNext(child1, child2) {
+  if (child1.type === TASK && child2.type === TASK_GROUP) {
+    return -1;
+  } else if (child1.type === TASK_GROUP && child2.type === TASK) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+export { addItem, removeItem };

--- a/src/views/TasksView/DragDropContext.jsx
+++ b/src/views/TasksView/DragDropContext.jsx
@@ -1,10 +1,12 @@
 import { invoke } from "@tauri-apps/api";
 import React, { createContext, useEffect, useState } from "react";
 
-const TASK = "Task";
-const TASK_GROUP = "TaskGroup";
-const TASKS_VIEW = "view";
-const TAURI_FETCH_TASKS = "get_tasks_view";
+import {
+  TASKS_VIEW,
+  TAURI_FETCH_TASKS,
+  TASK,
+  TASK_GROUP,
+} from "../../Constants";
 
 const DragDropContext = createContext();
 

--- a/src/views/TasksView/DragDropContext.jsx
+++ b/src/views/TasksView/DragDropContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useEffect, useState } from "react";
 
-import { TASK, TASK_GROUP } from "../../Constants";
+import { addItem, removeItem } from "../../utility/AddRemoveItems";
 
 const DragDropContext = createContext();
 
@@ -27,44 +27,14 @@ const DragDropProvider = ({ children, item }) => {
     setStructure((prevStructure) => {
       const newStructure = JSON.parse(JSON.stringify(prevStructure));
 
-      // Helper function to find and remove the item from its original location.
-      const removeItem = (id, node) => {
-        if (node.children) {
-          node.children = node.children.filter((child) => child.id !== id);
-          // If item not found in node.children, search and remove it from each child of node.children.
-          node.children.forEach((child) => removeItem(id, child));
-        }
-      };
       removeItem(droppedItemId, newStructure);
 
-      // Helper function to find the target group and add the item.
-      const addItem = (item, targetId, node) => {
-        if (node.id === targetId) {
-          if (!node.children) node.children = [];
-          node.children.push(item);
-          // Sorting & reversing so that sub-tasks appear above sub-groups.
-          node.children.sort(tasksFirstGroupsNext);
-        } else if (node.children) {
-          // Find and add the item in the group in which it needs to be added.
-          node.children.forEach((child) => addItem(item, targetId, child));
-        }
-      };
       addItem(draggedItem, targetId, newStructure);
 
       return newStructure;
     });
     setDraggedItem(null);
   };
-
-  function tasksFirstGroupsNext(child1, child2) {
-    if (child1.type === TASK && child2.type === TASK_GROUP) {
-      return -1;
-    } else if (child1.type === TASK_GROUP && child2.type === TASK) {
-      return 1;
-    } else {
-      return 0;
-    }
-  }
 
   return (
     <DragDropContext.Provider value={{ structure, handleOnDrag, handleOnDrop }}>

--- a/src/views/TasksView/DragDropContext.jsx
+++ b/src/views/TasksView/DragDropContext.jsx
@@ -23,8 +23,6 @@ const DragDropProvider = ({ children, item }) => {
     // droppedItemID is a string for whatever reason, convert it to number.
     // basically event.dataTransfer.getData() always returns a string.
     const droppedItemId = Number(event.dataTransfer.getData("text/plain"));
-    console.log(`droppedItemId: ${droppedItemId}`);
-    console.log(`targetId: ${targetId}`);
 
     setStructure((prevStructure) => {
       const newStructure = JSON.parse(JSON.stringify(prevStructure));
@@ -32,17 +30,7 @@ const DragDropProvider = ({ children, item }) => {
       // Helper function to find and remove the item from its original location.
       const removeItem = (id, node) => {
         if (node.children) {
-          node.children = node.children.filter((child) => {
-            console.log("child.id: " + child.id + " " + "droppedItemId: " + id);
-            console.log(
-              "typeof child.id: " +
-                typeof child.id +
-                " " +
-                "typeof droppedItemId: " +
-                typeof id
-            );
-            return child.id !== id;
-          });
+          node.children = node.children.filter((child) => child.id !== id);
           // If item not found in node.children, search and remove it from each child of node.children.
           node.children.forEach((child) => removeItem(id, child));
         }
@@ -51,20 +39,11 @@ const DragDropProvider = ({ children, item }) => {
 
       // Helper function to find the target group and add the item.
       const addItem = (item, targetId, node) => {
-        console.log("node.id: " + node.id + " " + "targetId: " + targetId);
-        console.log(
-          "typeof node.id: " +
-            typeof node.id +
-            " " +
-            "typeof targetId: " +
-            typeof targetId
-        );
         if (node.id === targetId) {
           if (!node.children) node.children = [];
           node.children.push(item);
           // Sorting & reversing so that sub-tasks appear above sub-groups.
           node.children.sort(tasksFirstGroupsNext);
-          console.log(children);
         } else if (node.children) {
           // Find and add the item in the group in which it needs to be added.
           node.children.forEach((child) => addItem(item, targetId, child));

--- a/src/views/TasksView/Navbar.jsx
+++ b/src/views/TasksView/Navbar.jsx
@@ -7,7 +7,7 @@ import { faTrashAlt, faEdit, faCheckCircle } from '@fortawesome/free-solid-svg-i
 
 // TODO: style this component.
 
-const Navbar = () => {
+const Navbar = ({ onAdd }) => {
   return (
     <nav className='nav'>
         <p className='page-title title'>Tasks</p>
@@ -16,11 +16,11 @@ const Navbar = () => {
                 <button className='btn'>Tommorow</button>
             </li>
             <li>
-                <button className='btn'>+</button>
+                <button className='btn' onClick={onAdd}>+</button>
             </li>
             <li>
                 <button className='btn'>Completed</button>
-                
+
             </li>
         </ul>
     </nav>

--- a/src/views/TasksView/Task.jsx
+++ b/src/views/TasksView/Task.jsx
@@ -8,6 +8,7 @@ import EditIcon from "@mui/icons-material/Edit";
 
 import { DragDropContext } from "./DragDropContext";
 import { TASK, TASKS_VIEW, TAURI_DELETE_TASK, TODAY } from "../../Constants";
+import { removeItem } from "../../utility/AddRemoveItems";
 
 const Task = (props) => {
   // Adds ID of dragged task to DragEvent datastore and changes state of the DragDropContext.
@@ -18,13 +19,18 @@ const Task = (props) => {
 
   const handleDelete = (e) => {
     e.preventDefault();
+
     invoke(TAURI_DELETE_TASK, {
       table: TODAY,
       id: props.id,
     });
-    sessionStorage.removeItem(TASKS_VIEW);
-    // TODO: NO RELOADING, DELETE FROM SESSIONSTORAGE.
-    location.reload();
+
+    let storedView = JSON.parse(sessionStorage.getItem(TASKS_VIEW));
+
+    removeItem(props.id, storedView);
+
+    sessionStorage.setItem(TASKS_VIEW, JSON.stringify(storedView));
+    props.onDelete();
   };
 
   return (

--- a/src/views/TasksView/Task.jsx
+++ b/src/views/TasksView/Task.jsx
@@ -1,10 +1,13 @@
 import React from "react";
+import { useContext } from "react";
+import { invoke } from "@tauri-apps/api";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
-import { DragDropContext } from "./DragDropContext";
-import { useContext } from "react";
+import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
+import EditIcon from "@mui/icons-material/Edit";
 
-import { TASK } from "../../Constants";
+import { DragDropContext } from "./DragDropContext";
+import { TASK, TASKS_VIEW, TAURI_DELETE_TASK, TODAY } from "../../Constants";
 
 const Task = (props) => {
   // Adds ID of dragged task to DragEvent datastore and changes state of the DragDropContext.
@@ -12,6 +15,17 @@ const Task = (props) => {
 
   /*Tried adding the edit symbol, but the entire screen just goes black?*/
   /* <FontAwesomeIcon icon={faEdit} className="icon edit-icon" /> */
+
+  const handleDelete = (e) => {
+    e.preventDefault();
+    invoke(TAURI_DELETE_TASK, {
+      table: TODAY,
+      id: props.id,
+    });
+    sessionStorage.removeItem(TASKS_VIEW);
+    // TODO: NO RELOADING, DELETE FROM SESSIONSTORAGE.
+    location.reload();
+  };
 
   return (
     <div
@@ -31,10 +45,14 @@ const Task = (props) => {
       </div>
       <ul>
         <li>
-          <button className="task-btn">Edit</button>
+          <button className="edit-icon">
+            <EditIcon />
+          </button>
         </li>
         <li>
-          <FontAwesomeIcon icon={faTrashAlt} className="delete-icon" />
+          <button className="delete-icon" onClick={handleDelete}>
+            <DeleteForeverIcon />
+          </button>
         </li>
       </ul>
     </div>

--- a/src/views/TasksView/Task.jsx
+++ b/src/views/TasksView/Task.jsx
@@ -4,7 +4,7 @@ import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { DragDropContext } from "./DragDropContext";
 import { useContext } from "react";
 
-const TASK = "Task";
+import { TASK } from "../../Constants";
 
 const Task = (props) => {
   // Adds ID of dragged task to DragEvent datastore and changes state of the DragDropContext.

--- a/src/views/TasksView/TaskGroup.jsx
+++ b/src/views/TasksView/TaskGroup.jsx
@@ -4,7 +4,7 @@ import { ROOT, TASK, TASK_GROUP } from "../../Constants";
 import Task from "./Task";
 import { DragDropContext } from "./DragDropContext";
 
-const TaskGroup = ({ id, name, children }) => {
+const TaskGroup = ({ id, name, children, onDelete }) => {
   const { handleOnDrop } = useContext(DragDropContext);
 
   return (
@@ -20,7 +20,14 @@ const TaskGroup = ({ id, name, children }) => {
         <div className="subtasks-list">
           {children.map((child) => {
             if (child.type === TASK) {
-              return <Task name={child.name} id={child.id} key={child.id} />;
+              return (
+                <Task
+                  name={child.name}
+                  id={child.id}
+                  key={child.id}
+                  onDelete={onDelete}
+                />
+              );
             } else if (child.type === TASK_GROUP) {
               return (
                 <TaskGroup
@@ -28,6 +35,7 @@ const TaskGroup = ({ id, name, children }) => {
                   id={child.id}
                   name={child.name}
                   children={child.children}
+                  onDelete={onDelete}
                 />
               );
             }

--- a/src/views/TasksView/TaskGroup.jsx
+++ b/src/views/TasksView/TaskGroup.jsx
@@ -1,11 +1,8 @@
 import React, { useContext } from "react";
 
+import { ROOT, TASK, TASK_GROUP } from "../../Constants";
 import Task from "./Task";
 import { DragDropContext } from "./DragDropContext";
-
-const ROOT = "/";
-const TASK = "Task";
-const TASK_GROUP = "TaskGroup";
 
 const TaskGroup = ({ id, name, children }) => {
   const { handleOnDrop } = useContext(DragDropContext);
@@ -13,7 +10,6 @@ const TaskGroup = ({ id, name, children }) => {
   return (
     <div
       className="taskgroup-container"
-      draggable
       onDrop={(e) => {
         handleOnDrop(e, id);
       }}

--- a/src/views/TasksView/TasksView.jsx
+++ b/src/views/TasksView/TasksView.jsx
@@ -54,27 +54,23 @@ const TasksView = () => {
       the JSON object in sessionStorage. SEE TOP TODO.
   */
   useEffect(() => {
-    console.log("in useEffect in TasksView");
 
     async function fetchTasks() {
       const storedTasks = sessionStorage.getItem(TASKS_VIEW);
       if (storedTasks) {
-        console.log("View fetched from sessionStorage.");
         setStructure(JSON.parse(storedTasks));
         return;
       }
       try {
-        console.log("fetching data...");
         const response = await invoke(TAURI_FETCH_TASKS);
-        console.log(response);
         const data = JSON.parse(response);
-        console.log(`fetched data: ${JSON.stringify(data)}`);
 
         // Set sessionStorage.
         sessionStorage.setItem(TASKS_VIEW, response);
 
         setStructure(data);
       } catch (error) {
+        // Deal with errors properly here.
         console.error("Error fetching tasks:", error);
       }
     }
@@ -91,7 +87,6 @@ const TasksView = () => {
   }
 
   const add = (option, name, parentName) => {
-    console.log("inside add()");
     const storedView = sessionStorage.getItem(TASKS_VIEW);
 
     function getId(node) {
@@ -117,17 +112,14 @@ const TasksView = () => {
       // show Error in the modal.
       return;
     }
-    console.log(`got id: ${parentGroupId}`);
 
     if (option === TASK) {
-      console.log("adding task");
       invoke(TAURI_ADD_TASK, {
         table: TODAY,
         name: name,
         parent_group_id: parentGroupId,
       });
     } else if (option === TASK_GROUP) {
-      console.log("adding group");
       invoke(TAURI_ADD_TASKGROUP, {
         table: TODAY,
         name: name,
@@ -136,7 +128,6 @@ const TasksView = () => {
     }
 
     sessionStorage.removeItem(TASKS_VIEW);
-    console.log("deleted session storage");
     setModalVisibility(false);
 
     // CHEAP TRICK. I NEED TO RELOAD THE WEBVIEW TO DISPLAY

--- a/src/views/TasksView/TasksView.jsx
+++ b/src/views/TasksView/TasksView.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Navbar from "./Navbar";
 
+import { TASKS_VIEW } from "../../Constants";
 import TaskGroup from "./TaskGroup";
 import { DragDropProvider, DragDropContext } from "./DragDropContext";
 
@@ -8,6 +9,12 @@ import { DragDropProvider, DragDropContext } from "./DragDropContext";
 // THIS IS CHANGED. NOW YOU HAVE TO INVOKE TASK IN DragDropProvider.jsx
 
 const TasksView = () => {
+  function add() {
+    // Add task/group.
+
+    sessionStorage.removeItem(TASKS_VIEW);
+  }
+
   return (
     <div className="box">
       <Navbar />

--- a/src/views/TasksView/TasksView.jsx
+++ b/src/views/TasksView/TasksView.jsx
@@ -1,45 +1,183 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Navbar from "./Navbar";
+import { invoke } from "@tauri-apps/api";
 
-import { TASKS_VIEW } from "../../Constants";
+import {
+  TODAY,
+  TASK,
+  TASKS_VIEW,
+  TASK_GROUP,
+  TAURI_FETCH_TASKS,
+  TAURI_ADD_TASK,
+  TAURI_ADD_TASKGROUP,
+} from "../../Constants";
+
 import TaskGroup from "./TaskGroup";
 import { DragDropProvider, DragDropContext } from "./DragDropContext";
+import AddItemModal from "../../components/AddItemModal";
 
-// // Invoke the task data from the database.
-// THIS IS CHANGED. NOW YOU HAVE TO INVOKE TASK IN DragDropProvider.jsx
+/*
+    TODO -> FEWER DATABASE QUERY OPTIMIZATION.
+            On addition, add the task to the database BUT
+            to generate the final structure, just use the addItem function
+            similar to the one in dragDropContext w some modifications.
+
+            Similarly, this approach can be used in task deletion as well.
+
+    TODO -> ERROR HANDLING.
+            We don't handle errors when the input string in
+            Parent Name in the add item model is not an actual
+            valid parent group.
+
+            Arnav's idea: Instead of a textbox, use a dropdown menu
+            to display the available parent groups.
+
+    TODO -> FIX CHEAP RELOAD TRICK.
+            Rn, we have to reload the page after adding a new task
+            or a group because I can't figure out how to get the new
+            item to be displayed without doing so.
+
+            Probably when the optimization mentioned above is implemented,
+            a reload will not be necessary. This is because, inevitably,
+            setStructure() will be called, leading to a re-render of the
+            TasksView component.
+*/
+
+const NOT_FOUND = -1;
 
 const TasksView = () => {
-  function add() {
-    // Add task/group.
+  const [showModal, setModalVisibility] = useState(false);
+  const [structure, setStructure] = useState("");
+
+  /*
+      Probably should not do this, and just add the task to
+      the JSON object in sessionStorage. SEE TOP TODO.
+  */
+  useEffect(() => {
+    console.log("in useEffect in TaskView");
+
+    async function fetchTasks() {
+      const storedTasks = sessionStorage.getItem(TASKS_VIEW);
+      if (storedTasks) {
+        console.log("View fetched from sessionStorage.");
+        setStructure(JSON.parse(storedTasks));
+        return;
+      }
+      try {
+        console.log("fetching data...");
+        const response = await invoke(TAURI_FETCH_TASKS);
+        console.log(response);
+        const data = JSON.parse(response);
+        console.log(`fetched data: ${JSON.stringify(data)}`);
+
+        // Set sessionStorage.
+        sessionStorage.setItem(TASKS_VIEW, response);
+
+        setStructure(data);
+      } catch (error) {
+        console.error("Error fetching tasks:", error);
+      }
+    }
+
+    fetchTasks();
+
+    // THE EMPTY DEPENDENCY ARRAY AS THE SECOND ARGUMENT OF
+    // useEffect() IS VERY IMPORTANT BECAUSE IT STOPS THE
+    // FUNCTION FROM RUNNING A BAJILLION TIMES.
+  }, []);
+
+  function seeModal() {
+    setModalVisibility(true);
+  }
+
+  const add = (option, name, parentName) => {
+    console.log("inside add()");
+    const storedView = sessionStorage.getItem(TASKS_VIEW);
+
+    function getId(node) {
+      // This will store the id of the parent if it is found, -1 if not.
+      let res = NOT_FOUND;
+
+      if (node.type === TASK_GROUP && node.name === parentName) {
+        return node.id;
+      } else if (node.type === TASK_GROUP && node.children) {
+        node.children.forEach((child) => {
+          let temp = getId(child);
+          if (temp != -1) {
+            res = temp;
+          }
+        });
+      }
+
+      return res;
+    }
+
+    const parentGroupId = getId(JSON.parse(storedView));
+    if (parentGroupId === NOT_FOUND) {
+      // show Error in the modal.
+      return;
+    }
+    console.log(`got id: ${parentGroupId}`);
+
+    if (option === TASK) {
+      console.log("adding task");
+      invoke(TAURI_ADD_TASK, {
+        table: TODAY,
+        name: name,
+        parent_group_id: parentGroupId,
+      });
+    } else if (option === TASK_GROUP) {
+      console.log("adding group");
+      invoke(TAURI_ADD_TASKGROUP, {
+        table: TODAY,
+        name: name,
+        parent_group_id: parentGroupId,
+      });
+    }
 
     sessionStorage.removeItem(TASKS_VIEW);
+    console.log("deleted session storage");
+    setModalVisibility(false);
+
+    // CHEAP TRICK. I NEED TO RELOAD THE WEBVIEW TO DISPLAY
+    // THE UPDATED TASKS VIEW W THE NEW TASK.
+    location.reload();
+  };
+
+  function closeModal() {
+    setModalVisibility(false);
   }
 
   return (
-    <div className="box">
-      <Navbar />
-      <div className="task-area">
-        {/* I don't understand how this works, but it works. */}
-        <DragDropProvider>
-          <DragDropContext.Consumer>
-            {/* This structure = initialStructure from DragDropContext.jsx */}
-            {/* Null check to ensure structure is populated w contents of db */}
-            {({ structure }) =>
-              structure ? (
-                <TaskGroup
-                  key={structure.id}
-                  id={structure.id}
-                  name={structure.name}
-                  children={structure.children}
-                />
-              ) : (
-                <p>loading...</p>
-              )
-            }
-          </DragDropContext.Consumer>
-        </DragDropProvider>
+    <>
+      <div className="box">
+        <Navbar onAdd={seeModal} />
+        <div className="task-area">
+          {/* I don't understand how this works, but it works. */}
+          <DragDropProvider item={structure}>
+            <DragDropContext.Consumer>
+              {/* This structure = initialStructure from DragDropContext.jsx */}
+              {/* Null check to ensure structure is populated w contents of db */}
+              {({ structure }) =>
+                structure ? (
+                  <TaskGroup
+                    key={structure.id}
+                    id={structure.id}
+                    name={structure.name}
+                    children={structure.children}
+                  />
+                ) : (
+                  <p>loading...</p>
+                )
+              }
+            </DragDropContext.Consumer>
+          </DragDropProvider>
+        </div>
       </div>
-    </div>
+      {showModal && (
+        <AddItemModal itemType={TASK} onAdd={add} onCancel={closeModal} />
+      )}
+    </>
   );
 };
 

--- a/src/views/TasksView/TasksView.jsx
+++ b/src/views/TasksView/TasksView.jsx
@@ -54,7 +54,7 @@ const TasksView = () => {
       the JSON object in sessionStorage. SEE TOP TODO.
   */
   useEffect(() => {
-    console.log("in useEffect in TaskView");
+    console.log("in useEffect in TasksView");
 
     async function fetchTasks() {
       const storedTasks = sessionStorage.getItem(TASKS_VIEW);
@@ -84,7 +84,7 @@ const TasksView = () => {
     // THE EMPTY DEPENDENCY ARRAY AS THE SECOND ARGUMENT OF
     // useEffect() IS VERY IMPORTANT BECAUSE IT STOPS THE
     // FUNCTION FROM RUNNING A BAJILLION TIMES.
-  }, []);
+  }, [sessionStorage]);
 
   function seeModal() {
     setModalVisibility(true);


### PR DESCRIPTION
Now you can:
- Add a task / group.
- Delete a task. (not groups yet)
- Then close the app, and when you open it, your app is just how you left it.
- Optimized to fast asf by reducing read write queries to the database.

Stuff left to work on in TasksView:
- The recursive nature of some backend and frontend functions.
- The frontend still is bad.
- Moving completed tasks to a different view, filtering tasks while fetching on the basis of their status.
- Editing tasks and deleting groups.
- Setting tomorrow's tasks and migrating them at midnight or the next day at first open.