### PR TITLE
Refactoring

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,11 +22,9 @@ fn main() {
         })
         .invoke_handler(tauri::generate_handler![
             ops::commands::get_tasks_view,
-            ops::commands::add_task,
-            ops::commands::add_task_group,
-            ops::commands::delete_task,
-            ops::commands::delete_task_group,
-            ops::commands::edit_task_or_group,
+            ops::commands::add_item,
+            ops::commands::delete_item,
+            ops::commands::edit_item,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/Constants.jsx
+++ b/src/Constants.jsx
@@ -11,11 +11,9 @@ const STREAKS_VIEW = "StreaksWatch";
 const TASK = "Task";
 const TASK_GROUP = "TaskGroup";
 const TAURI_FETCH_TASKS_VIEW = "get_tasks_view";
-const TAURI_ADD_TASK = "add_task";
-const TAURI_ADD_TASKGROUP = "add_task_group";
-const TAURI_DELETE_TASK = "delete_task";
-const TAURI_DELETE_GROUP = "delete_task_group";
-const TAURI_EDIT_TASK_OR_GROUP = "edit_task_or_group";
+const TAURI_ADD_ITEM = "add_item";
+const TAURI_DELETE_ITEM = "delete_item";
+const TAURI_EDIT_ITEM = "edit_item";
 
 export {
   // Table names
@@ -31,9 +29,7 @@ export {
   TASK,
   TASK_GROUP,
   TAURI_FETCH_TASKS_VIEW,
-  TAURI_ADD_TASK,
-  TAURI_ADD_TASKGROUP,
-  TAURI_DELETE_TASK,
-  TAURI_DELETE_GROUP,
-  TAURI_EDIT_TASK_OR_GROUP,
+  TAURI_ADD_ITEM,
+  TAURI_DELETE_ITEM,
+  TAURI_EDIT_ITEM,
 };

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -45,7 +45,6 @@ const Modal = ({ itemType, onAdd, onCancel }) => {
 
   function handleSubmit(e){
     e.preventDefault();
-    console.log(option + " " + name + " " + group);
     onAdd(option, name, group);
   };
 

--- a/src/utility/AddRemoveUpdateItems.jsx
+++ b/src/utility/AddRemoveUpdateItems.jsx
@@ -42,9 +42,7 @@ function tasksFirstGroupsNext(child1, child2) {
 
 const updateItem = (id, name, node) => {
   if (node.id === id) {
-    console.log("previous name: " + node.name);
     node.name = name;
-    console.log("updated name: " + node.name);
   } else if (node.children) {
     node.children.forEach((child) => updateItem(id, name, child));
   }

--- a/src/utility/UpdateFrontend.jsx
+++ b/src/utility/UpdateFrontend.jsx
@@ -1,0 +1,8 @@
+const updateFrontend = (itemFunction, view, onChangeView, ...args) => {
+  let storedView = JSON.parse(sessionStorage.getItem(view));
+  itemFunction(...args, storedView);
+  sessionStorage.setItem(view, JSON.stringify(storedView));
+  onChangeView();
+};
+
+export { updateFrontend };

--- a/src/views/TasksView/Task.jsx
+++ b/src/views/TasksView/Task.jsx
@@ -12,10 +12,11 @@ import {
   TASK,
   TASKS_VIEW,
   TODAY,
-  TAURI_DELETE_TASK,
-  TAURI_EDIT_TASK_OR_GROUP,
+  TAURI_DELETE_ITEM,
+  TAURI_EDIT_ITEM,
 } from "../../Constants";
 import { removeItem, updateItem } from "../../utility/AddRemoveUpdateItems";
+import { updateFrontend } from "../../utility/UpdateFrontend";
 
 const Task = (props) => {
   // Adds ID of dragged task to DragEvent datastore and changes state of the DragDropContext.
@@ -26,30 +27,28 @@ const Task = (props) => {
 
   useEffect(() => {
     if (editingTaskId) {
-      window.addEventListener('keydown', handleKeyDown);
+      window.addEventListener("keydown", handleKeyDown);
     } else {
-      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown);
     }
 
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    }
+      window.removeEventListener("keydown", handleKeyDown);
+    };
   }, [editingTaskId]);
 
   const handleDelete = (e) => {
     e.preventDefault();
 
     // Delete task from the database.
-    invoke(TAURI_DELETE_TASK, {
+    invoke(TAURI_DELETE_ITEM, {
       table: TODAY,
       id: props.id,
+      item_type: TASK,
     });
 
     // Delete task from the frontend.
-    let storedView = JSON.parse(sessionStorage.getItem(TASKS_VIEW));
-    removeItem(props.id, storedView);
-    sessionStorage.setItem(TASKS_VIEW, JSON.stringify(storedView));
-    props.onChangeTasksView();
+    updateFrontend(removeItem, TASKS_VIEW, props.onChangeTasksView, props.id);
   };
 
   function handleEdit() {
@@ -66,26 +65,29 @@ const Task = (props) => {
 
   function handleConfirmEdit() {
     // Update name in the database.
-    invoke(TAURI_EDIT_TASK_OR_GROUP, {
+    invoke(TAURI_EDIT_ITEM, {
       table: TODAY,
       name: editedName,
       id: props.id,
     });
 
     // Update name on the frontend.
-    const storedView = JSON.parse(sessionStorage.getItem(TASKS_VIEW));
-    updateItem(props.id, editedName, storedView);
-    sessionStorage.setItem(TASKS_VIEW, JSON.stringify(storedView));
+    updateFrontend(
+      updateItem,
+      TASKS_VIEW,
+      props.onChangeTasksView,
+      props.id,
+      editedName
+    );
 
     setEditingTaskId(null);
-    props.onChangeTasksView();
   }
 
   const handleKeyDown = (e) => {
-    if (e.key === 'Escape') {
+    if (e.key === "Escape") {
       cancelEdit();
     }
-  }
+  };
 
   function cancelEdit() {
     setEditedName(null);

--- a/src/views/TasksView/TaskGroup.jsx
+++ b/src/views/TasksView/TaskGroup.jsx
@@ -4,14 +4,14 @@ import { IconButton } from "@mui/material";
 import { MoreVert } from "@mui/icons-material";
 import { Menu } from "@mui/material";
 import { MenuItem } from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
+// import DeleteIcon from "@mui/icons-material/Delete";
 
 import {
   ROOT,
   TASK,
   TASKS_VIEW,
   TASK_GROUP,
-  TAURI_DELETE_GROUP,
+  TAURI_DELETE_ITEM,
   TODAY,
 } from "../../Constants";
 import Task from "./Task";
@@ -19,6 +19,7 @@ import { DragDropContext } from "./DragDropContext";
 import { invoke } from "@tauri-apps/api";
 import { removeItem } from "../../utility/AddRemoveUpdateItems";
 import AlertModal from "../../components/AlertModal";
+import { updateFrontend } from "../../utility/UpdateFrontend";
 
 const TaskGroup = ({ id, name, children, onChangeTasksView }) => {
   const [anchorEl, setAnchorEl] = useState(null);
@@ -34,7 +35,7 @@ const TaskGroup = ({ id, name, children, onChangeTasksView }) => {
 
   const open = Boolean(anchorEl);
 
-  function handleMenuItemClick(e, option) {
+  function handleMenuItemClick(option) {
     if (option === "Delete Group") {
       setAlertVisibility(true);
     }
@@ -49,17 +50,14 @@ const TaskGroup = ({ id, name, children, onChangeTasksView }) => {
 
   function deleteGroup() {
     // Deleting group from database.
-    invoke(TAURI_DELETE_GROUP, {
+    invoke(TAURI_DELETE_ITEM, {
       table: TODAY,
       id: id,
+      item_type: TASK_GROUP,
     });
 
     // Deleting group from front-end.
-    const storedView = JSON.parse(sessionStorage.getItem(TASKS_VIEW));
-    removeItem(id, storedView);
-    sessionStorage.setItem(TASKS_VIEW, JSON.stringify(storedView));
-    // To rerender TasksView.
-    onChangeTasksView();
+    updateFrontend(removeItem, TASKS_VIEW, onChangeTasksView, id);
   }
 
   function onCancel() {

--- a/src/views/TasksView/TasksView.jsx
+++ b/src/views/TasksView/TasksView.jsx
@@ -8,14 +8,14 @@ import {
   TASKS_VIEW,
   TASK_GROUP,
   TAURI_FETCH_TASKS_VIEW,
-  TAURI_ADD_TASK,
-  TAURI_ADD_TASKGROUP,
+  TAURI_ADD_ITEM,
 } from "../../Constants";
 
 import TaskGroup from "./TaskGroup";
 import { DragDropProvider, DragDropContext } from "./DragDropContext";
 import Modal from "../../components/Modal";
 import { addItem } from "../../utility/AddRemoveUpdateItems";
+import { updateFrontend } from "../../utility/UpdateFrontend";
 
 /*
     TODO -> ERROR HANDLING.
@@ -95,54 +95,33 @@ const TasksView = () => {
       return;
     }
 
-    if (option === TASK) {
-      invoke(TAURI_ADD_TASK, {
-        table: TODAY,
-        name: name,
-        parent_group_id: parentGroupId,
-      })
-        .then((id) => {
-          // Adding the new task to the view without having to fetch again.
-          addItem(
-            {
-              id: id,
-              name: name,
-              type: TASK,
-              is_active: true,
-              parent_group_id: parentGroupId,
-              children: null,
-            },
-            parentGroupId,
-            storedView
-          );
-          setStructure(storedView);
-          sessionStorage.setItem(TASKS_VIEW, JSON.stringify(storedView));
-        })
-        // TODO: ERROR HANDLING {i know you came here probably by ctrl+f-ing for console.log()s}
-        .catch((error) => console.log(error));
-    } else if (option === TASK_GROUP) {
-      invoke(TAURI_ADD_TASKGROUP, {
-        table: TODAY,
-        name: name,
-        parent_group_id: parentGroupId,
-      }).then((id) => {
-        // Adding the new group to the view without having to fetch again.
-        addItem(
+    invoke(TAURI_ADD_ITEM, {
+      table: TODAY,
+      name: name,
+      parent_group_id: parentGroupId,
+      item_type: option,
+    })
+      .then((id) => {
+        let isActive = option === TASK ? true : null;
+        let children = option === TASK ? null : [];
+        // Adding the new task to the view without having to fetch again.
+        updateFrontend(
+          addItem,
+          TASKS_VIEW,
+          onChangeTasksView,
           {
             id: id,
             name: name,
-            type: TASK_GROUP,
-            is_active: null,
+            type: option,
+            is_active: isActive,
             parent_group_id: parentGroupId,
-            children: [],
+            children: children,
           },
-          parentGroupId,
-          storedView
+          parentGroupId
         );
-        setStructure(storedView);
-        sessionStorage.setItem(TASKS_VIEW, JSON.stringify(storedView));
-      });
-    }
+      })
+      // TODO: ERROR HANDLING {i know you came here probably by ctrl+f-ing for console.log()s}
+      .catch((error) => console.log(error));
 
     setModalVisibility(false);
   };


### PR DESCRIPTION
# Frontend:
Refactored:
- how the tasks view object is updated upon an operation like addition, deletion and updation.
- the tauri command constants.

# Backend:
- removed redundant tauri commands; there is no real need to have two separate functions to add, delete and update tasks and groups.

# Todos:
- if god can give me the strength to understand lifetimes and why singletons have to worry about multi-thread safety when they were only ever supposed to run on one, refactor the way SQL commands are run.

# Overall Todos:
- fix the out-of-bounds error in Task.jsx #13
- `tomorrow`
- the scroll bars on windows, actually all OSs, are horrendously hideous and need to be styled so that my eyes can stop bleeding.
- if I double-finger swipe left or right on the app, the kind you do when you are on a laptop and want to go back to the previous tab on chrome, the app slides but the sidebar button doesn't. IMO the entire app shouldn't slide.