### PR TITLE
Leftover functionality

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -309,8 +309,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
 
@@ -1138,6 +1140,7 @@ dependencies = [
 name = "habtrack"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "lazy_static",
  "libsqlite3-sys",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = "0.31.0"
 lazy_static = "1.4.0"
+chrono = { version = "0.4.38", features = ["serde"] }
 
 [target.'cfg(windows)'.dependencies]
 libsqlite3-sys = { version = "0.28.0", features = ["bundled"] }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -203,7 +203,7 @@ pub mod ops {
                     name TEXT NOT NULL,
                     type TEXT NOT NULL,
                     is_active INTEGER,
-                    parent_group_id INTEGER,
+                    parent_group_id INTEGER
                 )",
                     [],
                 )?;
@@ -227,7 +227,7 @@ pub mod ops {
         fn migrate_tasks(&self) -> Result<()> {
             if let Some(conn) = &self.db_conn {
                 let today = Local::now().naive_local().date();
-                
+
                 let last_migration_date: Option<String> =
                     match conn
                         .query_row("SELECT MAX(date) FROM migration_log", [], |row| row.get(0))
@@ -243,7 +243,7 @@ pub mod ops {
                     // Migrate tasks
                     conn.execute(
                         &format!("INSERT INTO today (name, type, is_active, parent_group_id)
-                    (SELECT name, type, is_active, parent_group_id FROM tomorrow WHERE name!='{ROOT_GROUP}')"),
+                    SELECT name, type, is_active, parent_group_id FROM tomorrow WHERE name!='{ROOT_GROUP}'"),
                         [],
                     )?;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,9 +24,7 @@ fn main() {
             ops::commands::get_tasks_view,
             ops::commands::add_item,
             ops::commands::delete_item,
-            ops::commands::edit_item,
             ops::commands::update_item,
-            ops::commands::update_status_item,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
             ops::crud_commands::delete_item,
             ops::crud_commands::update_item,
             ops::app_commands::open_tomorrow_window,
+            ops::app_commands::close_tomorrow_window,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,10 +21,11 @@ fn main() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            ops::commands::get_tasks_view,
-            ops::commands::add_item,
-            ops::commands::delete_item,
-            ops::commands::update_item,
+            ops::crud_commands::get_tasks_view,
+            ops::crud_commands::add_item,
+            ops::crud_commands::delete_item,
+            ops::crud_commands::update_item,
+            ops::app_commands::open_tomorrow_window,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.css
+++ b/src/App.css
@@ -598,7 +598,14 @@ form .form-group select {
   gap: 1rem;
 }
 
-.page-title {
+.page-title-sidebar-closed {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin: 0 100px;
+  align-items: start;
+}
+
+.page-title-sidebar-open {
   font-size: 1.5rem;
   font-weight: bold;
   margin: 0;
@@ -987,10 +994,10 @@ form .form-group select {
 }
 
 .nav-add-btn {
-  width: 55px;
-  height: 55px;
+  width: 50px;
+  height: 50px;
   border-radius: 20px;
-  background-color: #286bb3;
+  background-color: #3576cc;
   border: none;
   font-weight: 600;
   display: flex;
@@ -1497,8 +1504,8 @@ redudant. Not putting under calendar chart styles for obvious reasons. */
   align-items: center;
   word-wrap: break-word;
   max-width: 250px;
-  overflow-wrap: break-word; 
-  word-break: break-all; 
+  overflow-wrap: break-word;
+  word-break: break-all;
   white-space: normal;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1272,6 +1272,70 @@ form .form-group select {
   background-color: var(--bg-color) !important;
 }
 
+.done-btn {
+  width: 55px;
+  height: 55px;
+  border-radius: 20px;
+  background-color: #286bb3;
+  border: none;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 10px 10px 10px black;
+  cursor: pointer;
+  transition-duration: 0.3s;
+  overflow: hidden;
+  position: relative;
+  text-decoration: none !important;
+}
+
+.done-btn svg {
+  width: 25px;
+  transition-duration: 0.3s;
+}
+
+.done-btn svg path {
+  fill: white;
+}
+
+.done-btn:hover {
+  width: 100px;
+  border-radius: 20px;
+  transition-duration: 0.3s;
+  background-color: #286bb3;
+  align-items: center;
+}
+
+.done-btn:hover .edit-svgIcon {
+  width: 20px;
+  transition-duration: 0.3s;
+  transform: translateY(60%);
+  -webkit-transform: rotate(360deg);
+  -moz-transform: rotate(360deg);
+  -o-transform: rotate(360deg);
+  -ms-transform: rotate(360deg);
+  transform: rotate(360deg);
+}
+
+.done-btn::after {
+  display: none;
+  padding: 7px;
+  content: "Save";
+  color: white;
+  transition-duration: 0.3s;
+  font-size: 5px;
+}
+
+.done-btn:hover::after {
+  display: block;
+  padding-right: 10px;
+  font-size: 15px;
+  opacity: 1;
+  transform: translateY(0px);
+  transition-duration: 0.3s;
+}
+
 /* -------------------------------------------------------------------------- */
 /* -----------------------------STREAKS VIEW STYLES-------------------------- */
 /* -------------------------------------------------------------------------- */

--- a/src/App.css
+++ b/src/App.css
@@ -865,6 +865,9 @@ form .form-group select {
   padding-bottom: 1rem;
   padding-left: 1rem;
   padding-right: 1rem;
+  /* word-break is used to break the word into lines */
+  word-break: break-all;
+  white-space: normal;
 }
 
 .taskgroup-container .taskgroup-container {
@@ -1072,6 +1075,16 @@ form .form-group select {
   align-items: center;
   padding: 12px;
   cursor: pointer;
+}
+
+.task-btn-tg {
+  background: transparent;
+  color: white;
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  cursor: pointer;
+  border: none;
 }
 
 .task-btn:hover {

--- a/src/App.css
+++ b/src/App.css
@@ -798,7 +798,7 @@ form .form-group select {
 }
 
 .progress {
-  content: '';
+  content: "";
   width: 1px;
   height: 3px;
   border-radius: 7px;
@@ -1051,7 +1051,7 @@ form .form-group select {
   font-size: 5px;
 }
 
-.nav-add-btn:hover::after{
+.nav-add-btn:hover::after {
   display: block;
   padding-right: 10px;
   font-size: 13px;
@@ -1252,8 +1252,6 @@ form .form-group select {
 .add-btn:hover {
   filter: brightness(120%);
 }
-
-
 
 .MuiMenu-list {
   display: flex;
@@ -1571,7 +1569,7 @@ redudant. Not putting under calendar chart styles for obvious reasons. */
   opacity: 1;
 }
 
-.day-type{
+.day-type {
   display: flex;
   align-items: center;
   left: 50px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,7 +52,7 @@ function App() {
           />
         )}
         <div className="main-area">
-          {tab === TASKS_VIEW && <TasksView />}
+          {tab === TASKS_VIEW && <TasksView isSidebarOpen={showSidebar}/>}
           {tab === HABITS_VIEW && <HabitsView />}
           {tab === STREAKS_VIEW && <StreaksWatchView />}
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 // Non-UI stuff.
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 // External UI Components
 import AssignmentIcon from "@mui/icons-material/Assignment";
@@ -28,6 +28,8 @@ function App() {
   const [tab, setTab] = useState(TASKS_VIEW);
   const [showSidebar, setSidebar] = useState(true);
 
+  const mainAreaRef = useRef(null);
+
   function toggleTab(newTab) {
     setTab(newTab);
   }
@@ -51,8 +53,8 @@ function App() {
             toggleSidebar={toggleSidebar}
           />
         )}
-        <div className="main-area">
-          {tab === TASKS_VIEW && <TasksView isSidebarOpen={showSidebar}/>}
+        <div className="main-area" ref={mainAreaRef}>
+          {tab === TASKS_VIEW && <TasksView isSidebarOpen={showSidebar} mainAreaRef={mainAreaRef}/>}
           {tab === HABITS_VIEW && <HabitsView />}
           {tab === STREAKS_VIEW && <StreaksWatchView />}
         </div>

--- a/src/Constants.jsx
+++ b/src/Constants.jsx
@@ -17,9 +17,7 @@ const COMPLETED_TASKS = false;
 const TAURI_FETCH_TASKS_VIEW = "get_tasks_view";
 const TAURI_ADD_ITEM = "add_item";
 const TAURI_DELETE_ITEM = "delete_item";
-const TAURI_EDIT_ITEM = "edit_item";
 const TAURI_UPDATE_ITEM = "update_item";
-const TAURI_UPDATE_STATUS_ITEM = "update_status_item";
 
 export {
   // Table names
@@ -42,7 +40,5 @@ export {
   TAURI_FETCH_TASKS_VIEW,
   TAURI_ADD_ITEM,
   TAURI_DELETE_ITEM,
-  TAURI_EDIT_ITEM,
   TAURI_UPDATE_ITEM,
-  TAURI_UPDATE_STATUS_ITEM,
 };

--- a/src/Constants.jsx
+++ b/src/Constants.jsx
@@ -1,9 +1,11 @@
 // Table names
 const TODAY = "today";
+const TOMORROW = "tomorrow";
 
 // Frontend Global.
 const ROOT = "/";
 const TASKS_VIEW = "Tasks";
+const TOMORROW_VIEW = "Tomorrow";
 const HABITS_VIEW = "Habits";
 const STREAKS_VIEW = "StreaksWatch";
 
@@ -21,14 +23,17 @@ const TAURI_UPDATE_ITEM = "update_item";
 
 // New Window.
 const TAURI_OPEN_TOMORROW_WINDOW = "open_tomorrow_window";
+const TAURI_CLOSE_TOMORROW_WINDOW = "close_tomorrow_window";
 
 export {
   // Table names
   TODAY,
+  TOMORROW,
 
   // Frontend Global
   ROOT,
   TASKS_VIEW,
+  TOMORROW_VIEW,
   HABITS_VIEW,
   STREAKS_VIEW,
 
@@ -47,4 +52,5 @@ export {
 
   // New Window,
   TAURI_OPEN_TOMORROW_WINDOW,
+  TAURI_CLOSE_TOMORROW_WINDOW,
 };

--- a/src/Constants.jsx
+++ b/src/Constants.jsx
@@ -19,6 +19,9 @@ const TAURI_ADD_ITEM = "add_item";
 const TAURI_DELETE_ITEM = "delete_item";
 const TAURI_UPDATE_ITEM = "update_item";
 
+// New Window.
+const TAURI_OPEN_TOMORROW_WINDOW = "open_tomorrow_window";
+
 export {
   // Table names
   TODAY,
@@ -41,4 +44,7 @@ export {
   TAURI_ADD_ITEM,
   TAURI_DELETE_ITEM,
   TAURI_UPDATE_ITEM,
+
+  // New Window,
+  TAURI_OPEN_TOMORROW_WINDOW,
 };

--- a/src/components/CompletedTasksModal.jsx
+++ b/src/components/CompletedTasksModal.jsx
@@ -8,10 +8,8 @@ import {
   COMPLETED_TASKS,
   TAURI_FETCH_TASKS_VIEW,
   TODAY,
-  TASK_GROUP,
   TASKS_VIEW,
-  TAURI_UPDATE_STATUS_ITEM,
-  ACTIVE_TASKS,
+  TAURI_UPDATE_ITEM,
 } from "../Constants";
 import { updateFrontend } from "../utility/UpdateFrontend";
 import { addItem } from "../utility/AddRemoveUpdateItems";
@@ -42,10 +40,10 @@ const CompletedTasksModal = ({ onChangeTasksView, onCancel }) => {
 
   const onUndo = (item) => {
     // Update db.
-    invoke(TAURI_UPDATE_STATUS_ITEM, {
+    invoke(TAURI_UPDATE_ITEM, {
       table: TODAY,
       id: item[0],
-      status: false,
+      field: { Status: false },
     });
 
     // Update frontend of completed tasks view.

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from "react";
-import { TASKS_VIEW, TASK_GROUP, TASK, ROOT } from "../Constants";
+import { TASK_GROUP, TASK, ROOT } from "../Constants";
 
-const Modal = ({ itemType, preselected, onAdd, onCancel }) => {
+const Modal = ({ view, preselected, onAdd, onCancel }) => {
   const [option, setOption] = useState(TASK);
   const [name, setName] = useState("");
-  const [group, setGroup] = useState(ROOT);
+  const [group, setGroup] = useState(preselected);
   const [groups, setAllGroups] = useState(null);
 
   useEffect(() => {
-    let storedView = JSON.parse(sessionStorage.getItem(TASKS_VIEW));
+    let storedView = JSON.parse(sessionStorage.getItem(view));
 
     const extractNames = (obj) => {
       let names = [];
@@ -95,7 +95,7 @@ const Modal = ({ itemType, preselected, onAdd, onCancel }) => {
                 <select
                   id="group"
                   onChange={handleGroupChange}
-                  defaultValue={preselected !== "" ? preselected : "/"}
+                  defaultValue={preselected}
                 >
                   {groups.map((group, idx) => (
                     <option key={idx} value={group}>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { TASKS_VIEW, TASK_GROUP, TASK, ROOT } from "../Constants";
 
-const Modal = ({ itemType, onAdd, onCancel }) => {
+const Modal = ({ itemType, preselected, onAdd, onCancel }) => {
   const [option, setOption] = useState(TASK);
   const [name, setName] = useState("");
   const [group, setGroup] = useState(ROOT);
@@ -50,15 +50,12 @@ const Modal = ({ itemType, onAdd, onCancel }) => {
 
   return (
     <div className="modal">
-
       <div className="close-x-btn">
-      <button className="x-btn">
-        <span className="X"></span>
-        <span className="Y"></span>
-      </button>
-
+        <button className="x-btn">
+          <span className="X"></span>
+          <span className="Y"></span>
+        </button>
       </div>
-
       <div className="modal-content">
         <h2>Add</h2>
         <div className="tab">
@@ -95,7 +92,11 @@ const Modal = ({ itemType, onAdd, onCancel }) => {
                 <label htmlFor="group">
                   <strong>Group:</strong>
                 </label>
-                <select id="group" onChange={handleGroupChange}>
+                <select
+                  id="group"
+                  onChange={handleGroupChange}
+                  defaultValue={preselected !== "" ? preselected : "/"}
+                >
                   {groups.map((group, idx) => (
                     <option key={idx} value={group}>
                       {group}

--- a/src/utility/UpdateFrontend.jsx
+++ b/src/utility/UpdateFrontend.jsx
@@ -2,7 +2,9 @@ const updateFrontend = (itemFunction, view, onChangeView, ...args) => {
   let storedView = JSON.parse(sessionStorage.getItem(view));
   itemFunction(...args, storedView);
   sessionStorage.setItem(view, JSON.stringify(storedView));
-  onChangeView();
+  if (onChangeView != null) {
+    onChangeView();
+  }
 };
 
 export { updateFrontend };

--- a/src/views/TasksView/DragDropContext.jsx
+++ b/src/views/TasksView/DragDropContext.jsx
@@ -29,7 +29,7 @@ const DragDropProvider = ({ children, item }) => {
     invoke(TAURI_UPDATE_ITEM, {
       table: TODAY,
       id: droppedItemId,
-      new_parent_group_id: targetId,
+      field: { Parent: targetId },
     });
 
     setStructure((prevStructure) => {

--- a/src/views/TasksView/DragDropContext.jsx
+++ b/src/views/TasksView/DragDropContext.jsx
@@ -2,11 +2,17 @@ import React, { createContext, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api";
 
 import { addItem, removeItem } from "../../utility/AddRemoveUpdateItems";
-import { TODAY, TASKS_VIEW, TAURI_UPDATE_ITEM } from "../../Constants";
+import {
+  TASKS_VIEW,
+  TAURI_UPDATE_ITEM,
+  TODAY,
+  TOMORROW_VIEW,
+} from "../../Constants";
+import { updateFrontend } from "../../utility/UpdateFrontend";
 
 const DragDropContext = createContext();
 
-const DragDropProvider = ({ children, item }) => {
+const DragDropProvider = ({ children, item, dbTable }) => {
   const [structure, setStructure] = useState();
   const [draggedItem, setDraggedItem] = useState(null);
 
@@ -27,17 +33,16 @@ const DragDropProvider = ({ children, item }) => {
     const droppedItemId = Number(event.dataTransfer.getData("text/plain"));
 
     invoke(TAURI_UPDATE_ITEM, {
-      table: TODAY,
+      table: dbTable,
       id: droppedItemId,
       field: { Parent: targetId },
     });
 
-    setStructure((prevStructure) => {
-      const newStructure = JSON.parse(JSON.stringify(prevStructure));
-      removeItem(droppedItemId, newStructure);
-      addItem(draggedItem, targetId, newStructure);
-      sessionStorage.setItem(TASKS_VIEW, JSON.stringify(newStructure));
-      return newStructure;
+    setStructure(() => {
+      const view = dbTable === TODAY ? TASKS_VIEW : TOMORROW_VIEW;
+      updateFrontend(removeItem, view, null, droppedItemId);
+      updateFrontend(addItem, view, null, draggedItem, targetId);
+      return JSON.parse(sessionStorage.getItem(view));
     });
     setDraggedItem(null);
   };

--- a/src/views/TasksView/Navbar.jsx
+++ b/src/views/TasksView/Navbar.jsx
@@ -19,7 +19,7 @@ const Navbar = ({ isSidebarOpen, onAdd, toggleCompleted }) => {
       </p>
       <ul>
         <li>
-          <button className="btn" title="Set Tasks for Tommorow">
+          <button className="btn" title="Set Tasks for Tomorrow">
             <FastForwardIcon />
           </button>
         </li>

--- a/src/views/TasksView/Navbar.jsx
+++ b/src/views/TasksView/Navbar.jsx
@@ -2,10 +2,21 @@ import React from "react";
 import PlaylistAddCheckIcon from "@mui/icons-material/PlaylistAddCheck";
 import FastForwardIcon from "@mui/icons-material/FastForward";
 import AddIcon from "@mui/icons-material/Add";
+import { invoke } from "@tauri-apps/api";
+import { TAURI_OPEN_TOMORROW_WINDOW } from "../../Constants";
 
 // TODO: style this component.
 
 const Navbar = ({ isSidebarOpen, onAdd, toggleCompleted }) => {
+  const seeTomorrow = async () => {
+    try {
+      await invoke(TAURI_OPEN_TOMORROW_WINDOW);
+      console.log('Tomorrow window opened');
+    } catch (error) {
+      console.error('Error opening tomorrow window:', error);
+    }
+  };
+
   return (
     <nav className="nav">
       <p
@@ -19,7 +30,7 @@ const Navbar = ({ isSidebarOpen, onAdd, toggleCompleted }) => {
       </p>
       <ul>
         <li>
-          <button className="btn" title="Set Tasks for Tomorrow">
+          <button className="btn" title="Set Tasks for Tomorrow" onClick={seeTomorrow}>
             <FastForwardIcon />
           </button>
         </li>

--- a/src/views/TasksView/Navbar.jsx
+++ b/src/views/TasksView/Navbar.jsx
@@ -3,7 +3,7 @@ import PlaylistAddCheckIcon from "@mui/icons-material/PlaylistAddCheck";
 import FastForwardIcon from "@mui/icons-material/FastForward";
 import AddIcon from "@mui/icons-material/Add";
 import { invoke } from "@tauri-apps/api";
-import { TAURI_OPEN_TOMORROW_WINDOW } from "../../Constants";
+import { ROOT, TAURI_OPEN_TOMORROW_WINDOW } from "../../Constants";
 
 // TODO: style this component.
 
@@ -35,7 +35,7 @@ const Navbar = ({ isSidebarOpen, onAdd, toggleCompleted }) => {
           </button>
         </li>
         <li>
-          <button className="nav-add-btn" onClick={() => onAdd("")} title="Add Task">
+          <button className="nav-add-btn" onClick={() => onAdd(ROOT)} title="Add Task">
             <AddIcon fontSize="medium"></AddIcon>
           </button>
         </li>

--- a/src/views/TasksView/Navbar.jsx
+++ b/src/views/TasksView/Navbar.jsx
@@ -24,7 +24,7 @@ const Navbar = ({ isSidebarOpen, onAdd, toggleCompleted }) => {
           </button>
         </li>
         <li>
-          <button className="nav-add-btn" onClick={onAdd} title="Add Task">
+          <button className="nav-add-btn" onClick={() => onAdd("")} title="Add Task">
             <AddIcon fontSize="medium"></AddIcon>
           </button>
         </li>

--- a/src/views/TasksView/Navbar.jsx
+++ b/src/views/TasksView/Navbar.jsx
@@ -5,10 +5,16 @@ import AddIcon from "@mui/icons-material/Add";
 
 // TODO: style this component.
 
-const Navbar = ({ onAdd, toggleCompleted }) => {
+const Navbar = ({ isSidebarOpen, onAdd, toggleCompleted }) => {
   return (
     <nav className="nav">
-      <p className="page-title title">
+      <p
+        className={
+          isSidebarOpen
+            ? "page-title-sidebar-open title"
+            : "page-title-sidebar-closed title"
+        }
+      >
         Tasks
       </p>
       <ul>
@@ -23,7 +29,11 @@ const Navbar = ({ onAdd, toggleCompleted }) => {
           </button>
         </li>
         <li>
-          <button className="btn" onClick={toggleCompleted} title='Check Completed Task'>
+          <button
+            className="btn"
+            onClick={toggleCompleted}
+            title="Check Completed Task"
+          >
             <PlaylistAddCheckIcon fontSize="medium"></PlaylistAddCheckIcon>
           </button>
         </li>

--- a/src/views/TasksView/Task.jsx
+++ b/src/views/TasksView/Task.jsx
@@ -13,8 +13,7 @@ import {
   TASKS_VIEW,
   TODAY,
   TAURI_DELETE_ITEM,
-  TAURI_EDIT_ITEM,
-  TAURI_UPDATE_STATUS_ITEM,
+  TAURI_UPDATE_ITEM,
 } from "../../Constants";
 import { removeItem, updateItem } from "../../utility/AddRemoveUpdateItems";
 import { updateFrontend } from "../../utility/UpdateFrontend";
@@ -67,10 +66,10 @@ const Task = (props) => {
 
   function handleConfirmEdit() {
     // Update name in the database.
-    invoke(TAURI_EDIT_ITEM, {
+    invoke(TAURI_UPDATE_ITEM, {
       table: TODAY,
-      name: editedName,
       id: props.id,
+      field: { Name: editedName },
     });
 
     // Update name on the frontend.
@@ -105,10 +104,10 @@ const Task = (props) => {
     await sleep(1500);
     setCompleted(false);
     // Update database.
-    invoke(TAURI_UPDATE_STATUS_ITEM, {
+    invoke(TAURI_UPDATE_ITEM, {
       table: TODAY,
       id: props.id,
-      status: true,
+      field: { Status: true },
     });
 
     // Update frontend.

--- a/src/views/TasksView/Task.jsx
+++ b/src/views/TasksView/Task.jsx
@@ -159,7 +159,10 @@ const Task = (props) => {
       <ul>
         {editingTaskId === props.id ? (
           <li>
-            <button className="task-btn" onClick={handleConfirmEdit}>
+            <button
+              className="task-btn"
+              onClick={editedName !== "" ? handleConfirmEdit : null}
+            >
               <CheckIcon />
             </button>
           </li>

--- a/src/views/TasksView/Task.jsx
+++ b/src/views/TasksView/Task.jsx
@@ -14,14 +14,16 @@ import {
   TODAY,
   TAURI_DELETE_ITEM,
   TAURI_UPDATE_ITEM,
+  TOMORROW_VIEW,
 } from "../../Constants";
 import { removeItem, updateItem } from "../../utility/AddRemoveUpdateItems";
 import { updateFrontend } from "../../utility/UpdateFrontend";
 
 const Task = (props) => {
+  const view = props.dbTable === TODAY ? TASKS_VIEW : TOMORROW_VIEW;
+
   // Adds ID of dragged task to DragEvent datastore and changes state of the DragDropContext.
   const { handleOnDrag } = useContext(DragDropContext);
-
   const [editingTaskId, setEditingTaskId] = useState(null);
   const [editedName, setEditedName] = useState(null);
   const [isCompleted, setCompleted] = useState(false);
@@ -43,13 +45,13 @@ const Task = (props) => {
 
     // Delete task from the database.
     invoke(TAURI_DELETE_ITEM, {
-      table: TODAY,
+      table: props.dbTable,
       id: props.id,
       item_type: TASK,
     });
 
     // Delete task from the frontend.
-    updateFrontend(removeItem, TASKS_VIEW, props.onChangeTasksView, props.id);
+    updateFrontend(removeItem, view, props.onChangeView, props.id);
   };
 
   function handleEdit() {
@@ -67,7 +69,7 @@ const Task = (props) => {
   function handleConfirmEdit() {
     // Update name in the database.
     invoke(TAURI_UPDATE_ITEM, {
-      table: TODAY,
+      table: props.dbTable,
       id: props.id,
       field: { Name: editedName },
     });
@@ -75,8 +77,8 @@ const Task = (props) => {
     // Update name on the frontend.
     updateFrontend(
       updateItem,
-      TASKS_VIEW,
-      props.onChangeTasksView,
+      view,
+      props.onChangeView,
       props.id,
       editedName
     );
@@ -105,13 +107,13 @@ const Task = (props) => {
     setCompleted(false);
     // Update database.
     invoke(TAURI_UPDATE_ITEM, {
-      table: TODAY,
+      table: props.dbTable,
       id: props.id,
       field: { Status: true },
     });
 
     // Update frontend.
-    updateFrontend(removeItem, TASKS_VIEW, props.onChangeTasksView, props.id);
+    updateFrontend(removeItem, view, props.onChangeView, props.id);
   }
 
   return (

--- a/src/views/TasksView/Task.jsx
+++ b/src/views/TasksView/Task.jsx
@@ -177,6 +177,7 @@ const Task = (props) => {
           type="checkbox"
           defaultChecked="false"
           onClick={handleCompletion}
+          disabled={props.dbTable === TODAY ? false : true}
         />
         <div className="checkmark"></div>
       </label>

--- a/src/views/TasksView/TaskGroup.jsx
+++ b/src/views/TasksView/TaskGroup.jsx
@@ -15,6 +15,7 @@ import {
   TAURI_DELETE_ITEM,
   TAURI_UPDATE_ITEM,
   TODAY,
+  TOMORROW_VIEW,
 } from "../../Constants";
 import Task from "./Task";
 import { DragDropContext } from "./DragDropContext";
@@ -27,9 +28,12 @@ const TaskGroup = ({
   id,
   name,
   children,
-  onChangeTasksView,
+  onChangeView,
   preselectGroup,
+  dbTable
 }) => {
+  const view = dbTable === TODAY ? TASKS_VIEW : TOMORROW_VIEW;
+
   const [anchorEl, setAnchorEl] = useState(null);
   const [showAlert, setAlertVisibility] = useState(false);
   const [editingTaskId, setEditingTaskId] = useState(null);
@@ -75,13 +79,13 @@ const TaskGroup = ({
   function handleConfirmEdit() {
     // Update name in the database.
     invoke(TAURI_UPDATE_ITEM, {
-      table: TODAY,
+      table: dbTable,
       id: id,
       field: { Name: editedName },
     });
 
     // Update name on the frontend.
-    updateFrontend(updateItem, TASKS_VIEW, onChangeTasksView, id, editedName);
+    updateFrontend(updateItem, view, onChangeView, id, editedName);
 
     setEditingTaskId(null);
   }
@@ -114,13 +118,13 @@ const TaskGroup = ({
   function deleteGroup() {
     // Deleting group from database.
     invoke(TAURI_DELETE_ITEM, {
-      table: TODAY,
+      table: dbTable,
       id: id,
       item_type: TASK_GROUP,
     });
 
     // Deleting group from front-end.
-    updateFrontend(removeItem, TASKS_VIEW, onChangeTasksView, id);
+    updateFrontend(removeItem, view, onChangeView, id);
   }
 
   function onCancel() {
@@ -210,7 +214,8 @@ const TaskGroup = ({
                   name={child.name}
                   type={TASK}
                   isActive={child.is_active}
-                  onChangeTasksView={onChangeTasksView}
+                  onChangeView={onChangeView}
+                  dbTable={dbTable}
                 />
               );
             } else if (child.type === TASK_GROUP) {
@@ -221,8 +226,9 @@ const TaskGroup = ({
                   name={child.name}
                   type={TASK_GROUP}
                   children={child.children}
-                  onChangeTasksView={onChangeTasksView}
+                  onChangeView={onChangeView}
                   preselectGroup={preselectGroup}
+                  dbTable={dbTable}
                 />
               );
             }

--- a/src/views/TasksView/TaskGroup.jsx
+++ b/src/views/TasksView/TaskGroup.jsx
@@ -23,7 +23,13 @@ import { removeItem, updateItem } from "../../utility/AddRemoveUpdateItems";
 import AlertModal from "../../components/AlertModal";
 import { updateFrontend } from "../../utility/UpdateFrontend";
 
-const TaskGroup = ({ id, name, children, onChangeTasksView }) => {
+const TaskGroup = ({
+  id,
+  name,
+  children,
+  onChangeTasksView,
+  preselectGroup,
+}) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const [showAlert, setAlertVisibility] = useState(false);
   const [editingTaskId, setEditingTaskId] = useState(null);
@@ -91,9 +97,9 @@ const TaskGroup = ({ id, name, children, onChangeTasksView }) => {
   function handleMenuItemClick(option) {
     if (option === "Edit") {
       handleEdit();
-    }
-
-    if (option === "Delete Group") {
+    } else if (option === "Add Task") {
+      preselectGroup(name);
+    } else if (option === "Delete Group") {
       setAlertVisibility(true);
     }
 
@@ -216,6 +222,7 @@ const TaskGroup = ({ id, name, children, onChangeTasksView }) => {
                   type={TASK_GROUP}
                   children={child.children}
                   onChangeTasksView={onChangeTasksView}
+                  preselectGroup={preselectGroup}
                 />
               );
             }

--- a/src/views/TasksView/TaskGroup.jsx
+++ b/src/views/TasksView/TaskGroup.jsx
@@ -13,7 +13,7 @@ import {
   TASKS_VIEW,
   TASK_GROUP,
   TAURI_DELETE_ITEM,
-  TAURI_EDIT_ITEM,
+  TAURI_UPDATE_ITEM,
   TODAY,
 } from "../../Constants";
 import Task from "./Task";
@@ -74,10 +74,10 @@ const TaskGroup = ({
 
   function handleConfirmEdit() {
     // Update name in the database.
-    invoke(TAURI_EDIT_ITEM, {
+    invoke(TAURI_UPDATE_ITEM, {
       table: TODAY,
-      name: editedName,
       id: id,
+      field: { Name: editedName },
     });
 
     // Update name on the frontend.

--- a/src/views/TasksView/TaskGroup.jsx
+++ b/src/views/TasksView/TaskGroup.jsx
@@ -1,9 +1,10 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useEffect } from "react";
 
 import { IconButton } from "@mui/material";
 import { MoreVert } from "@mui/icons-material";
 import { Menu } from "@mui/material";
 import { MenuItem } from "@mui/material";
+import CheckIcon from "@mui/icons-material/Check";
 // import DeleteIcon from "@mui/icons-material/Delete";
 
 import {
@@ -12,20 +13,72 @@ import {
   TASKS_VIEW,
   TASK_GROUP,
   TAURI_DELETE_ITEM,
+  TAURI_EDIT_ITEM,
   TODAY,
 } from "../../Constants";
 import Task from "./Task";
 import { DragDropContext } from "./DragDropContext";
 import { invoke } from "@tauri-apps/api";
-import { removeItem } from "../../utility/AddRemoveUpdateItems";
+import { removeItem, updateItem } from "../../utility/AddRemoveUpdateItems";
 import AlertModal from "../../components/AlertModal";
 import { updateFrontend } from "../../utility/UpdateFrontend";
 
 const TaskGroup = ({ id, name, children, onChangeTasksView }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const [showAlert, setAlertVisibility] = useState(false);
+  const [editingTaskId, setEditingTaskId] = useState(null);
+  const [editedName, setEditedName] = useState("");
 
   const { handleOnDrop } = useContext(DragDropContext);
+
+  useEffect(() => {
+    if (editingTaskId) {
+      window.addEventListener("keydown", handleKeyDown);
+    } else {
+      window.removeEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [editingTaskId]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Escape") {
+      cancelEdit();
+    }
+  };
+
+  function cancelEdit() {
+    setEditedName(null);
+    setEditingTaskId(null);
+  }
+
+  function handleEdit() {
+    if (editingTaskId) {
+      setEditingTaskId(null);
+    } else {
+      setEditingTaskId(id);
+    }
+  }
+
+  function onChange(e) {
+    setEditedName(e.target.value);
+  }
+
+  function handleConfirmEdit() {
+    // Update name in the database.
+    invoke(TAURI_EDIT_ITEM, {
+      table: TODAY,
+      name: editedName,
+      id: id,
+    });
+
+    // Update name on the frontend.
+    updateFrontend(updateItem, TASKS_VIEW, onChangeTasksView, id, editedName);
+
+    setEditingTaskId(null);
+  }
 
   const groupOptions = ["Edit", "Add Task", "Delete Group"];
 
@@ -36,6 +89,10 @@ const TaskGroup = ({ id, name, children, onChangeTasksView }) => {
   const open = Boolean(anchorEl);
 
   function handleMenuItemClick(option) {
+    if (option === "Edit") {
+      handleEdit();
+    }
+
     if (option === "Delete Group") {
       setAlertVisibility(true);
     }
@@ -76,39 +133,65 @@ const TaskGroup = ({ id, name, children, onChangeTasksView }) => {
       }}
       onDragOver={(e) => e.preventDefault()}
     >
-      {name !== ROOT && (
-        <div className="group-header">
-          {name !== ROOT && <h3 className="bold">{name}</h3>}
-          <IconButton
-            style={{ color: "white", alignSelf: "start" }}
-            aria-label="more"
-            onClick={handleClick}
-            aria-haspopup="true"
-            aria-controls="long-menu"
+      {editingTaskId === id ? (
+        <div
+          className="edit-items"
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <input
+            type="text"
+            className="edit-task-inp bold"
+            onInput={onChange}
+            placeholder="press ESC key to stop editing..."
+            autoFocus
+          />
+          <button
+            className="task-btn-tg"
+            onClick={editedName !== "" ? handleConfirmEdit : null}
           >
-            <MoreVert />
-          </IconButton>
-          {/* Use IconMenu instead for better looks. Add icon -> Add task etc.*/}
-          <Menu
-            anchorEl={anchorEl}
-            keepMounted
-            onClose={handleClose}
-            open={open}
-            MenuListProps={{
-              display: "flex",
-              "flex-direction": "column",
-            }}
-          >
-            {groupOptions.map((option) => (
-              <MenuItem
-                key={option}
-                onClick={() => handleMenuItemClick(option)}
-              >
-                {option}
-              </MenuItem>
-            ))}
-          </Menu>
+            <CheckIcon />
+          </button>
         </div>
+      ) : (
+        <>
+          {name !== ROOT && (
+            <div className="group-header">
+              {name !== ROOT && <h3 className="bold">{name}</h3>}
+              <IconButton
+                style={{ color: "white", alignSelf: "start" }}
+                aria-label="more"
+                onClick={handleClick}
+                aria-haspopup="true"
+                aria-controls="long-menu"
+              >
+                <MoreVert />
+              </IconButton>
+              <Menu
+                anchorEl={anchorEl}
+                keepMounted
+                onClose={handleClose}
+                open={open}
+                MenuListProps={{
+                  display: "flex",
+                  "flex-direction": "column",
+                }}
+              >
+                {groupOptions.map((option) => (
+                  <MenuItem
+                    key={option}
+                    onClick={() => handleMenuItemClick(option)}
+                  >
+                    {option}
+                  </MenuItem>
+                ))}
+              </Menu>
+            </div>
+          )}
+        </>
       )}
       {children.length > 0 ? (
         <div className="subtasks-list">

--- a/src/views/TasksView/TaskGroup.jsx
+++ b/src/views/TasksView/TaskGroup.jsx
@@ -30,7 +30,8 @@ const TaskGroup = ({
   children,
   onChangeView,
   preselectGroup,
-  dbTable
+  dbTable,
+  taskViewRef,
 }) => {
   const view = dbTable === TODAY ? TASKS_VIEW : TOMORROW_VIEW;
 
@@ -216,6 +217,7 @@ const TaskGroup = ({
                   isActive={child.is_active}
                   onChangeView={onChangeView}
                   dbTable={dbTable}
+                  taskViewRef={taskViewRef}
                 />
               );
             } else if (child.type === TASK_GROUP) {
@@ -229,6 +231,7 @@ const TaskGroup = ({
                   onChangeView={onChangeView}
                   preselectGroup={preselectGroup}
                   dbTable={dbTable}
+                  taskViewRef={taskViewRef}
                 />
               );
             }

--- a/src/views/TasksView/TasksView.jsx
+++ b/src/views/TasksView/TasksView.jsx
@@ -35,6 +35,7 @@ const TasksView = ({isSidebarOpen}) => {
   const [showModal, setModalVisibility] = useState(false);
   const [structure, setStructure] = useState("");
   const [showCompleted, setCompletedTasksVisibility] = useState(false);
+  const [preselectGroup, setPreselectGroup] = useState("");
 
   /*
       Probably should not do this, and just add the task to
@@ -71,7 +72,8 @@ const TasksView = ({isSidebarOpen}) => {
     // FUNCTION FROM RUNNING A BAJILLION TIMES.
   }, []);
 
-  function seeModal() {
+  function seeModal(name) {
+    setPreselectGroup(name);
     setModalVisibility(true);
   }
 
@@ -133,9 +135,9 @@ const TasksView = ({isSidebarOpen}) => {
   };
 
   function closeModal(type) {
-    if (type === "Add") {
+    if (type === "AddModal") {
       setModalVisibility(false);
-    } else if (type === "Completed") {
+    } else if (type === "CompletedModal") {
       setCompletedTasksVisibility(false);
     }
   }
@@ -166,6 +168,7 @@ const TasksView = ({isSidebarOpen}) => {
                     name={structure.name}
                     children={structure.children}
                     onChangeTasksView={onChangeTasksView}
+                    preselectGroup={seeModal}
                   />
                 ) : (
                   <p>loading...</p>
@@ -176,10 +179,10 @@ const TasksView = ({isSidebarOpen}) => {
         </div>
       </div>
       {showModal && (
-        <Modal itemType={TASK} onAdd={add} onCancel={() => closeModal("Add")} />
+        <Modal itemType={TASKS_VIEW} preselected={preselectGroup} onAdd={add} onCancel={() => closeModal("AddModal")} />
       )}
       {showCompleted && (
-        <CompletedTasksModal onChangeTasksView={onChangeTasksView} onCancel={() => closeModal("Completed")} />
+        <CompletedTasksModal onChangeTasksView={onChangeTasksView} onCancel={() => closeModal("CompletedModal")} />
       )}
     </>
   );

--- a/src/views/TasksView/TasksView.jsx
+++ b/src/views/TasksView/TasksView.jsx
@@ -32,7 +32,7 @@ import CompletedTasksModal from "../../components/CompletedTasksModal";
 
 const NOT_FOUND = -1;
 
-const TasksView = ({ isSidebarOpen }) => {
+const TasksView = ({ isSidebarOpen, mainAreaRef }) => {
   const [showModal, setModalVisibility] = useState(false);
   const [structure, setStructure] = useState("");
   const [showCompleted, setCompletedTasksVisibility] = useState(false);
@@ -176,6 +176,7 @@ const TasksView = ({ isSidebarOpen }) => {
                     onChangeView={onChangeTasksView}
                     preselectGroup={seeModal}
                     dbTable={TODAY}
+                    taskViewRef={mainAreaRef}
                   />
                 ) : (
                   <p>loading...</p>

--- a/src/views/TasksView/TasksView.jsx
+++ b/src/views/TasksView/TasksView.jsx
@@ -10,6 +10,7 @@ import {
   TASK_GROUP,
   TAURI_FETCH_TASKS_VIEW,
   TAURI_ADD_ITEM,
+  ROOT,
 } from "../../Constants";
 
 import TaskGroup from "./TaskGroup";
@@ -31,11 +32,11 @@ import CompletedTasksModal from "../../components/CompletedTasksModal";
 
 const NOT_FOUND = -1;
 
-const TasksView = ({isSidebarOpen}) => {
+const TasksView = ({ isSidebarOpen }) => {
   const [showModal, setModalVisibility] = useState(false);
   const [structure, setStructure] = useState("");
   const [showCompleted, setCompletedTasksVisibility] = useState(false);
-  const [preselectGroup, setPreselectGroup] = useState("");
+  const [preselectGroup, setPreselectGroup] = useState(ROOT);
 
   /*
       Probably should not do this, and just add the task to
@@ -153,10 +154,15 @@ const TasksView = ({isSidebarOpen}) => {
   return (
     <>
       <div className="box">
-        <Navbar isSidebarOpen={isSidebarOpen} onAdd={seeModal} toggleCompleted={toggleCompleted} />
+        <Navbar
+          isSidebarOpen={isSidebarOpen}
+          onAdd={seeModal}
+          toggleCompleted={toggleCompleted}
+          onChangeView={onChangeTasksView}
+        />
         <div className="task-area">
           {/* I don't understand how this works, but it works. */}
-          <DragDropProvider item={structure}>
+          <DragDropProvider item={structure} dbTable={TODAY}>
             <DragDropContext.Consumer>
               {/* This structure = initialStructure from DragDropContext.jsx */}
               {/* Null check to ensure structure is populated w contents of db */}
@@ -167,8 +173,9 @@ const TasksView = ({isSidebarOpen}) => {
                     id={structure.id}
                     name={structure.name}
                     children={structure.children}
-                    onChangeTasksView={onChangeTasksView}
+                    onChangeView={onChangeTasksView}
                     preselectGroup={seeModal}
+                    dbTable={TODAY}
                   />
                 ) : (
                   <p>loading...</p>
@@ -179,10 +186,18 @@ const TasksView = ({isSidebarOpen}) => {
         </div>
       </div>
       {showModal && (
-        <Modal itemType={TASKS_VIEW} preselected={preselectGroup} onAdd={add} onCancel={() => closeModal("AddModal")} />
+        <Modal
+          view={TASKS_VIEW}
+          preselected={preselectGroup}
+          onAdd={add}
+          onCancel={() => closeModal("AddModal")}
+        />
       )}
       {showCompleted && (
-        <CompletedTasksModal onChangeTasksView={onChangeTasksView} onCancel={() => closeModal("CompletedModal")} />
+        <CompletedTasksModal
+          onChangeTasksView={onChangeTasksView}
+          onCancel={() => closeModal("CompletedModal")}
+        />
       )}
     </>
   );

--- a/src/views/TasksView/TasksView.jsx
+++ b/src/views/TasksView/TasksView.jsx
@@ -31,7 +31,7 @@ import CompletedTasksModal from "../../components/CompletedTasksModal";
 
 const NOT_FOUND = -1;
 
-const TasksView = () => {
+const TasksView = ({isSidebarOpen}) => {
   const [showModal, setModalVisibility] = useState(false);
   const [structure, setStructure] = useState("");
   const [showCompleted, setCompletedTasksVisibility] = useState(false);
@@ -151,7 +151,7 @@ const TasksView = () => {
   return (
     <>
       <div className="box">
-        <Navbar onAdd={seeModal} toggleCompleted={toggleCompleted} />
+        <Navbar isSidebarOpen={isSidebarOpen} onAdd={seeModal} toggleCompleted={toggleCompleted} />
         <div className="task-area">
           {/* I don't understand how this works, but it works. */}
           <DragDropProvider item={structure}>

--- a/src/views/TasksView/Tomorrow/TomorrowNavbar.jsx
+++ b/src/views/TasksView/Tomorrow/TomorrowNavbar.jsx
@@ -19,7 +19,7 @@ const TomorrowNavbar = ({ onAdd, onDone}) => {
         </li>
         <li>
           <button
-            className="btn"
+            className="done-btn"
             onClick={onDone}
             title="Save"
           >

--- a/src/views/TasksView/Tomorrow/TomorrowNavbar.jsx
+++ b/src/views/TasksView/Tomorrow/TomorrowNavbar.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import AddIcon from "@mui/icons-material/Add";
+import BeenhereIcon from '@mui/icons-material/Beenhere';
+import { ROOT } from "../../../Constants";
+
+const TomorrowNavbar = ({ onAdd, onDone}) => {
+  return (
+    <nav className="nav">
+      <p className={"page-title-sidebar-closed title"}>Tomorrow's Tasks</p>
+      <ul>
+        <li>
+          <button
+            className="nav-add-btn"
+            onClick={() => onAdd(ROOT)}
+            title="Add Task"
+          >
+            <AddIcon fontSize="medium"></AddIcon>
+          </button>
+        </li>
+        <li>
+          <button
+            className="btn"
+            onClick={onDone}
+            title="Save"
+          >
+            <BeenhereIcon />
+          </button>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default TomorrowNavbar;

--- a/src/views/TasksView/Tomorrow/TomorrowView.jsx
+++ b/src/views/TasksView/Tomorrow/TomorrowView.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const TomorrowView = () => {
+  return (
+    <div>Tomorrow</div>
+  )
+}
+
+export default TomorrowView

--- a/src/views/TasksView/Tomorrow/TomorrowView.jsx
+++ b/src/views/TasksView/Tomorrow/TomorrowView.jsx
@@ -1,9 +1,179 @@
-import React from 'react'
+import React, { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api";
+
+import "../../../App.css";
+import {
+  TOMORROW,
+  ROOT,
+  TASK,
+  TASK_GROUP,
+  TOMORROW_VIEW,
+  TAURI_CLOSE_TOMORROW_WINDOW,
+  TAURI_FETCH_TASKS_VIEW,
+  ACTIVE_TASKS,
+  TAURI_ADD_ITEM,
+} from "../../../Constants";
+import { DragDropProvider, DragDropContext } from "../DragDropContext";
+import TaskGroup from "../TaskGroup";
+import Modal from "../../../components/Modal";
+import { addItem } from "../../../utility/AddRemoveUpdateItems";
+import { updateFrontend } from "../../../utility/UpdateFrontend";
+import TomorrowNavbar from "./TomorrowNavbar";
+
+const NOT_FOUND = -1;
 
 const TomorrowView = () => {
-  return (
-    <div>Tomorrow</div>
-  )
-}
+  const [structure, setStructure] = useState(null);
+  const [preselectGroup, setPreselectGroup] = useState(ROOT);
+  const [showModal, setModalVisibility] = useState(false);
 
-export default TomorrowView
+  useEffect(() => {
+    async function fetchTasks() {
+      const storedView = sessionStorage.getItem(TOMORROW_VIEW);
+      if (storedView) {
+        setStructure(JSON.parse(storedView));
+        return;
+      }
+      try {
+        const response = await invoke(TAURI_FETCH_TASKS_VIEW, {
+          table: TOMORROW,
+          status: ACTIVE_TASKS,
+        });
+        const data = JSON.parse(response);
+
+        // Set sessionStorage.
+        sessionStorage.setItem(TOMORROW_VIEW, response);
+
+        setStructure(data);
+      } catch (error) {
+        // Deal with errors properly here.
+        console.error("Error fetching tasks:", error);
+      }
+    }
+
+    fetchTasks();
+
+    // THE EMPTY DEPENDENCY ARRAY AS THE SECOND ARGUMENT OF
+    // useEffect() IS VERY IMPORTANT BECAUSE IT STOPS THE
+    // FUNCTION FROM RUNNING A BAJILLION TIMES.
+  }, []);
+
+  const onChangeTomorrowView = () => {
+    setStructure(JSON.parse(sessionStorage.getItem(TOMORROW_VIEW)));
+  };
+
+  const seeModal = (name) => {
+    setPreselectGroup(name);
+    setModalVisibility(true);
+  };
+
+  const closeModal = () => {
+    setModalVisibility(false);
+  };
+
+  const add = (option, name, parentName) => {
+    function getId(node) {
+      // This will store the id of the parent if it is found, -1 if not.
+      let res = NOT_FOUND;
+
+      if (node.type === TASK_GROUP && node.name === parentName) {
+        return node.id;
+      } else if (node.type === TASK_GROUP && node.children) {
+        node.children.forEach((child) => {
+          let temp = getId(child);
+          if (temp != -1) {
+            res = temp;
+          }
+        });
+      }
+
+      return res;
+    }
+
+    const storedView = JSON.parse(sessionStorage.getItem(TOMORROW_VIEW));
+    const parentGroupId = getId(storedView);
+    if (parentGroupId === NOT_FOUND) {
+      // show Error in the modal.
+      return;
+    }
+
+    invoke(TAURI_ADD_ITEM, {
+      table: TOMORROW,
+      name: name,
+      parent_group_id: parentGroupId,
+      item_type: option,
+    })
+      .then((id) => {
+        let isActive = option === TASK ? true : null;
+        let children = option === TASK ? null : [];
+        // Adding the new task to the view without having to fetch again.
+        updateFrontend(
+          addItem,
+          TOMORROW_VIEW,
+          onChangeTomorrowView,
+          {
+            id: id,
+            name: name,
+            type: option,
+            is_active: isActive,
+            parent_group_id: parentGroupId,
+            children: children,
+          },
+          parentGroupId
+        );
+      })
+      // TODO: ERROR HANDLING {i know you came here probably by ctrl+f-ing for console.log()s}
+      .catch((error) => console.log(error));
+
+    setModalVisibility(false);
+  };
+
+  const onDone = async () => {
+    try {
+      await invoke(TAURI_CLOSE_TOMORROW_WINDOW);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  return (
+    <>
+      <div className="box">
+        <TomorrowNavbar onAdd={seeModal} onDone={onDone} />
+        <div className="task-area">
+          <DragDropProvider item={structure} dbTable={TOMORROW}>
+            <DragDropContext.Consumer>
+              {/* This structure = initialStructure from DragDropContext.jsx */}
+              {/* Null check to ensure structure is populated w contents of db */}
+              {({ structure }) =>
+                structure ? (
+                  <TaskGroup
+                    key={structure.id}
+                    id={structure.id}
+                    name={structure.name}
+                    children={structure.children}
+                    onChangeView={onChangeTomorrowView}
+                    preselectGroup={seeModal}
+                    dbTable={TOMORROW}
+                  />
+                ) : (
+                  <p>loading...</p>
+                )
+              }
+            </DragDropContext.Consumer>
+          </DragDropProvider>
+        </div>
+      </div>
+      {showModal && (
+        <Modal
+          view={TOMORROW_VIEW}
+          preselected={preselectGroup}
+          onAdd={add}
+          onCancel={() => closeModal("AddModal")}
+        />
+      )}
+    </>
+  );
+};
+
+export default TomorrowView;

--- a/src/views/TasksView/Tomorrow/index.html
+++ b/src/views/TasksView/Tomorrow/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tomorrow</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/views/TasksView/Tomorrow/main.jsx"></script>
+  </body>
+</html>

--- a/src/views/TasksView/Tomorrow/main.jsx
+++ b/src/views/TasksView/Tomorrow/main.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import TomorrowView from "./TomorrowView";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <TomorrowView />
+  </React.StrictMode>,
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { resolve } from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
+
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+        tomorrow: resolve(__dirname, "src/views/TasksView/Tomorrow/index.html"),
+      },
+    },
+  },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //


### PR DESCRIPTION
- Tomorrow is fully complete, I don't think there are ANY issues left.
- The remaining options of a TaskGroup have been implemented.
- Refactoring to make code of all CRUD commands more readable.

## Todos:
- In the options of a TaskGroup, instead of "Add Task", it should be "Add Item" or just "Add".
- Refactoring of `DbInitializer` struct into a new file. Basically, the structure should be:
-- src
| -> main.rs
| -> lib.rs
| -- db
| -- | -> db_ops.rs { will contain the ops module }
| -- | -> db_init.rs { will contain the init module }
| -- | -> mod.rs

## Features left:
- Export to pdf. I can't do it through react and I cannot figure out how to do it with a python script. Do it in rust.
- Help and introduction modal.