### PR TITLE
Habits

### DIFF
--- a/.github/workflows/test_build_on_push_pr.yml
+++ b/.github/workflows/test_build_on_push_pr.yml
@@ -2,13 +2,9 @@ name: "test-build-on-push-and-pr"
 
 on:
   push:
-    branches-ignore:
-      - 'main'
-  pull_request:
-    branches-ignore:
-      - 'main'
     branches:
       - '**'  # This makes the workflow run on pushes to any branch.
+  pull_request:
 
 # This workflow will build your Tauri app without uploading it anywhere.
 

--- a/src-tauri/src/db/habits.rs
+++ b/src-tauri/src/db/habits.rs
@@ -41,10 +41,7 @@ pub enum ToDelete {
 pub mod commands {
     use rusqlite::{params, Connection};
     use std::collections::HashMap;
-    use std::sync::Mutex;
     use tauri::State;
-
-    type CompMap = Mutex<HashMap<u64, bool>>;
 
     use super::{DayType, History, ToDelete};
     use crate::db::{

--- a/src-tauri/src/db/habits.rs
+++ b/src-tauri/src/db/habits.rs
@@ -1,39 +1,130 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Habit {
-	id: u64,
-	name: String,
-	streak: u64,
-	highest_streak: u64,
+    id: u64,
+    name: String,
+    streak: u64,
+    highest_streak: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DayType {
-	id: u64,
-	habit_id: u64,
-	name: String,
-	color: String,
+    id: u64,
+    habit_id: u64,
+    name: String,
+    color: String,
 }
 
 pub mod commands {
+    use std::collections::HashMap;
+
+    use crate::db::{habits::Habit, init::DbConn};
+    use rusqlite::{params, Connection};
     use tauri::State;
-    use crate::db::init::DbConn;
 
-    use super::{DayType, Habit};
+    #[tauri::command(rename_all = "snake_case")]
+    pub fn add_habit(
+        db_conn: State<'_, DbConn>,
+        name: String,
+        day_types: Vec<(String, String)>,
+    ) -> (i64, HashMap<String, i64>) {
+        let conn = db_conn.lock().unwrap();
+        let command =
+            format!("INSERT INTO habits (name, streak, highest_streak) VALUES (?1, ?2, ?3)");
+        let mut stmt = conn
+            .prepare(&command)
+            .expect("[ERROR] Could not prepare insertion of habit command!");
 
-    #[tauri::command(rename_all="snake_case")]
-    pub fn add_habit(db_conn: State<'_, DbConn>, habit: Habit, day_types: Vec<DayType>) {}
+        let id = stmt
+            .insert(params![name, 0, 0])
+            .expect("[ERROR] Could not insert habit!");
 
-    #[tauri::command(rename_all="snake_case")]
-    pub fn fetch_habits(db_conn: State<'_, DbConn>) {}
+        // Maps the name of the day_type to its id.
+        let day_types_map = day_types
+            .into_iter()
+            .map(|(dt_name, color)| {
+                let dt_id = insert_day_type(&conn, id, dt_name.as_str(), color);
 
-    #[tauri::command(rename_all="snake_case")]
-    pub fn increment_streak(db_conn: State<'_, DbConn>, habit_id: u64) {}
+                (dt_name, dt_id)
+            })
+            .collect::<HashMap<String, i64>>();
 
-    #[tauri::command(rename_all="snake_case")]
+        (id, day_types_map)
+    }
+
+    #[tauri::command(rename_all = "snake_case")]
+    pub fn add_day_type(
+        db_conn: State<'_, DbConn>,
+        habit_id: i64,
+        dt_name: String,
+        color: String,
+    ) -> i64 {
+        let conn = db_conn.lock().unwrap();
+
+        insert_day_type(&conn, habit_id, &dt_name, color)
+    }
+
+    #[tauri::command(rename_all = "snake_case")]
+    pub fn fetch_habits(db_conn: State<'_, DbConn>) -> String {
+        let conn = db_conn.lock().unwrap();
+
+        let mut stmt = conn
+            .prepare("SELECT * FROM habits")
+            .expect("[ERROR] Could not prepare statement to fetch all habits!");
+        let habits = match stmt.query_map([], |row| {
+            let id: u64 = row.get(0)?;
+            let name: String = row.get(1)?;
+            let streak: u64 = row.get(2)?;
+            let highest_streak: u64 = row.get(3)?;
+
+            Ok(Habit {
+                id,
+                name,
+                streak,
+                highest_streak,
+            })
+        }) {
+            Err(e) => panic!("[ERROR] Could not fetch habits: {e}"),
+            Ok(iterator) => iterator
+                .filter(|habit_op| habit_op.is_ok())
+                .map(|habit_op| match habit_op {
+                    Ok(habit) => habit,
+                    Err(e) => {
+                        panic!("[ERROR] Wtf why is Err() still here? I specifically didn't ask for it: {e}")
+                    }
+                })
+                .collect::<Vec<Habit>>(),
+        };
+
+        serde_json::to_string(&habits)
+            .expect("[ERROR] Could not convert habit vector into a JSON object")
+    }
+
+    #[tauri::command(rename_all = "snake_case")]
+    pub fn increment_streak(db_conn: State<'_, DbConn>, habit_id: u64, dt_id: u64) {
+        // Update streak.
+        // Add record in history.
+    }
+
+    #[tauri::command(rename_all = "snake_case")]
     pub fn delete_habit(db_conn: State<'_, DbConn>, habit_id: u64) {}
 
-    #[tauri::command(rename_all="snake_case")]
-    pub fn delete_day_type(db_conn: State<'_, DbConn>, dt_id: u64) {}
+    #[tauri::command(rename_all = "snake_case")]
+    pub fn delete_day_types(db_conn: State<'_, DbConn>, habits_id: u64) {}
+
+    #[tauri::command(rename_all = "snake_case")]
+    pub fn delete_history(db_conn: State<'_, DbConn>, habit_id: u64) {}
+
+    /* ------------------------------------ Helper Functions ------------------------------------ */
+
+    fn insert_day_type(conn: &Connection, habit_id: i64, dt_name: &str, color: String) -> i64 {
+        let command = format!("INSERT INTO day_types (habit_id, name, color) VALUES (?1, ?2, ?3)");
+        let mut stmt = conn
+            .prepare(&command)
+            .expect("[ERROR] Could not prepare day type insertion command!");
+
+        stmt.insert(params![habit_id, dt_name, color])
+            .expect("[ERROR] Could not insert day type!")
+    }
 }

--- a/src-tauri/src/db/habits.rs
+++ b/src-tauri/src/db/habits.rs
@@ -18,6 +18,7 @@ pub struct DayType {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "to_delete")]
 pub enum ToDelete {
     All,
     One(u64),
@@ -38,7 +39,7 @@ pub mod commands {
         db_conn: State<'_, DbConn>,
         name: String,
         day_types: Vec<(String, String)>,
-    ) -> (i64, HashMap<String, (i64, String)>) {
+    ) -> (i64, HashMap<String, i64>) {
         let conn = db_conn.lock().unwrap();
 
         let command =
@@ -57,9 +58,9 @@ pub mod commands {
             .map(|(dt_name, color)| {
                 let dt_id = insert_day_type(&conn, id, dt_name.as_str(), &color);
 
-                (dt_name, (dt_id, color))
+                (dt_name, dt_id)
             })
-            .collect::<HashMap<String, (i64, String)>>();
+            .collect::<HashMap<String, i64>>();
 
         (id, day_types_map)
     }

--- a/src-tauri/src/db/habits.rs
+++ b/src-tauri/src/db/habits.rs
@@ -6,14 +6,21 @@ pub struct Habit {
     name: String,
     streak: u64,
     highest_streak: u64,
+    day_types: Vec<DayType>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct DayType {
     id: u64,
     habit_id: u64,
     name: String,
     color: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum ToDelete {
+    All,
+    One(u64),
 }
 
 pub mod commands {
@@ -23,13 +30,17 @@ pub mod commands {
     use rusqlite::{params, Connection};
     use tauri::State;
 
+    use super::{DayType, ToDelete};
+
+    /// (C)RUD -> Create a habit.
     #[tauri::command(rename_all = "snake_case")]
     pub fn add_habit(
         db_conn: State<'_, DbConn>,
         name: String,
         day_types: Vec<(String, String)>,
-    ) -> (i64, HashMap<String, i64>) {
+    ) -> (i64, HashMap<String, (i64, String)>) {
         let conn = db_conn.lock().unwrap();
+
         let command =
             format!("INSERT INTO habits (name, streak, highest_streak) VALUES (?1, ?2, ?3)");
         let mut stmt = conn
@@ -44,15 +55,16 @@ pub mod commands {
         let day_types_map = day_types
             .into_iter()
             .map(|(dt_name, color)| {
-                let dt_id = insert_day_type(&conn, id, dt_name.as_str(), color);
+                let dt_id = insert_day_type(&conn, id, dt_name.as_str(), &color);
 
-                (dt_name, dt_id)
+                (dt_name, (dt_id, color))
             })
-            .collect::<HashMap<String, i64>>();
+            .collect::<HashMap<String, (i64, String)>>();
 
         (id, day_types_map)
     }
 
+    /// (C)RUD -> Create a day type for a habit.
     #[tauri::command(rename_all = "snake_case")]
     pub fn add_day_type(
         db_conn: State<'_, DbConn>,
@@ -62,9 +74,10 @@ pub mod commands {
     ) -> i64 {
         let conn = db_conn.lock().unwrap();
 
-        insert_day_type(&conn, habit_id, &dt_name, color)
+        insert_day_type(&conn, habit_id, &dt_name, &color)
     }
 
+    /// C(R)UD -> Fetch all habits.
     #[tauri::command(rename_all = "snake_case")]
     pub fn fetch_habits(db_conn: State<'_, DbConn>) -> String {
         let conn = db_conn.lock().unwrap();
@@ -78,17 +91,20 @@ pub mod commands {
             let streak: u64 = row.get(2)?;
             let highest_streak: u64 = row.get(3)?;
 
+            let day_types = fetch_day_types(&conn, id);
+
             Ok(Habit {
                 id,
                 name,
                 streak,
                 highest_streak,
+                day_types
             })
         }) {
             Err(e) => panic!("[ERROR] Could not fetch habits: {e}"),
             Ok(iterator) => iterator
-                .filter(|habit_op| habit_op.is_ok())
-                .map(|habit_op| match habit_op {
+                .filter(|habit_res| habit_res.is_ok())
+                .map(|habit_res| match habit_res {
                     Ok(habit) => habit,
                     Err(e) => {
                         panic!("[ERROR] Wtf why is Err() still here? I specifically didn't ask for it: {e}")
@@ -101,24 +117,62 @@ pub mod commands {
             .expect("[ERROR] Could not convert habit vector into a JSON object")
     }
 
+    // Note: This will update the highest_streak value if the streak exceeds it, but
+    // the frontend will have no way of knowing that. Therefore, it needs to be handled
+    // in the frontend separately.
+    /// CR(U)D -> Increment the streak for a habit.
     #[tauri::command(rename_all = "snake_case")]
     pub fn increment_streak(db_conn: State<'_, DbConn>, habit_id: u64, dt_id: u64) {
+        let conn = db_conn.lock().unwrap();
+
         // Update streak.
+        match conn.execute(
+            "UPDATE habits SET streak = streak + 1 WHERE id=(?1)",
+            params![habit_id],
+        ) {
+            Ok(_) => (),
+            Err(e) => panic!("[ERROR] Could not increment streak: {e}"),
+        };
+        match conn.execute(
+            "UPDATE habits SET highest_streak = streak WHERE highest_streak < streak",
+            [],
+        ) {
+            Ok(_) => (),
+            Err(e) => panic!("[ERROR] Could not increment streak: {e}"),
+        };
+
         // Add record in history.
+        let command = format!("INSERT INTO history VALUES (?1, ?2)");
+        let mut stmt = conn
+            .prepare(&command)
+            .expect("[ERROR] Could not prepare insertion into history command.");
+        stmt.insert(params![habit_id, dt_id])
+            .expect("[ERROR] Could not insert into history!");
     }
 
+    /// CRU(D) -> Delete a single or all day types of a habit.
     #[tauri::command(rename_all = "snake_case")]
-    pub fn delete_habit(db_conn: State<'_, DbConn>, habit_id: u64) {}
+    pub fn delete_day_type(db_conn: State<'_, DbConn>, habit_id: u64, how_many: ToDelete) {
+        let conn = db_conn.lock().unwrap();
 
-    #[tauri::command(rename_all = "snake_case")]
-    pub fn delete_day_types(db_conn: State<'_, DbConn>, habits_id: u64) {}
+        delete_dt_helper(&conn, habit_id, how_many);
+    }
 
+    /// CRU(D) -> Delete a habit.
     #[tauri::command(rename_all = "snake_case")]
-    pub fn delete_history(db_conn: State<'_, DbConn>, habit_id: u64) {}
+    pub fn delete_habit(db_conn: State<'_, DbConn>, habit_id: u64) {
+        let conn = db_conn.lock().unwrap();
+
+        delete_history(&conn, habit_id);
+        delete_dt_helper(&conn, habit_id, ToDelete::All);
+
+        conn.execute("DELETE FROM habits WHERE id=(?1)", params![habit_id])
+            .expect("[ERROR] Could not delete habit!");
+    }
 
     /* ------------------------------------ Helper Functions ------------------------------------ */
 
-    fn insert_day_type(conn: &Connection, habit_id: i64, dt_name: &str, color: String) -> i64 {
+    fn insert_day_type(conn: &Connection, habit_id: i64, dt_name: &str, color: &str) -> i64 {
         let command = format!("INSERT INTO day_types (habit_id, name, color) VALUES (?1, ?2, ?3)");
         let mut stmt = conn
             .prepare(&command)
@@ -126,5 +180,54 @@ pub mod commands {
 
         stmt.insert(params![habit_id, dt_name, color])
             .expect("[ERROR] Could not insert day type!")
+    }
+
+    fn fetch_day_types(conn: &Connection, habit_id: u64) -> Vec<DayType> {
+        let command = format!("SELECT id, name, color FROM day_types WHERE habit_id = {habit_id}");
+        let mut stmt = conn
+            .prepare(&command)
+            .expect("[ERROR] Cannot prepare statement that retrieves a habit's day types!");
+
+        let day_types = match stmt.query_map([], |row| {
+            let dt_id = row.get(0)?;
+            let dt_name = row.get(1)?;
+            let dt_color = row.get(2)?;
+
+            Ok(DayType {
+                id: dt_id,
+                habit_id,
+                name: dt_name,
+                color: dt_color,
+            })
+        }) {
+            Err(e) => panic!("[ERROR] Could not fetch day types for habit {habit_id}: {e}"),
+            Ok(dt_iter) => dt_iter.filter(|dt_res| dt_res.is_ok()).map(|dt_res| match dt_res {
+                Ok(dt) => dt,
+                Err(e) => panic!("[ERROR] Wtf why is Err() still here in DT? I specifically didn't ask for it: {e}"),
+            }).collect::<Vec<DayType>>(),
+        };
+
+        day_types
+    }
+
+    fn delete_history(conn: &Connection, habit_id: u64) -> u64 {
+        conn.execute("DELETE FROM history WHERE habit_id=(?1)", params![habit_id])
+            .expect("[ERROR] Could not erase history of the habit!") as u64
+    }
+
+    fn delete_dt_helper(conn: &Connection, habit_id: u64, how_many: ToDelete) {
+        match how_many {
+            ToDelete::All => {
+                conn.execute(
+                    "DELETE FROM day_types WHERE habit_id=(?1)",
+                    params![habit_id],
+                )
+                .expect("[ERROR] Could not delete day types of the habit!");
+            }
+            ToDelete::One(dt_id) => {
+                conn.execute("DELETE FROM day_types WHERE id=(?1)", params![dt_id])
+                    .expect("[ERROR] Could not delete one day type!");
+            }
+        }
     }
 }

--- a/src-tauri/src/db/habits.rs
+++ b/src-tauri/src/db/habits.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Habit {
+	id: u64,
+	name: String,
+	streak: u64,
+	highest_streak: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DayType {
+	id: u64,
+	habit_id: u64,
+	name: String,
+	color: String,
+}
+
+pub mod commands {
+    use tauri::State;
+    use crate::db::init::DbConn;
+
+    use super::{DayType, Habit};
+
+    #[tauri::command(rename_all="snake_case")]
+    pub fn add_habit(db_conn: State<'_, DbConn>, habit: Habit, day_types: Vec<DayType>) {}
+
+    #[tauri::command(rename_all="snake_case")]
+    pub fn fetch_habits(db_conn: State<'_, DbConn>) {}
+
+    #[tauri::command(rename_all="snake_case")]
+    pub fn increment_streak(db_conn: State<'_, DbConn>, habit_id: u64) {}
+
+    #[tauri::command(rename_all="snake_case")]
+    pub fn delete_habit(db_conn: State<'_, DbConn>, habit_id: u64) {}
+
+    #[tauri::command(rename_all="snake_case")]
+    pub fn delete_day_type(db_conn: State<'_, DbConn>, dt_id: u64) {}
+}

--- a/src-tauri/src/db/init.rs
+++ b/src-tauri/src/db/init.rs
@@ -176,7 +176,7 @@ pub mod habits {
             [],
         )?;
 
-        // DAY TYPES
+        // HISTORY
         conn.execute(
             "CREATE TABLE IF NOT EXISTS history (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -195,7 +195,7 @@ pub mod habits {
     pub fn validate_streaks(conn: &Connection) -> SQLiteResult<()> {
         // Obtain all habit_ids.
         let mut stmt = conn.prepare("SELECT id FROM habits")?;
-        let habits = stmt
+        let all_habits = stmt
             .query_map([], |row| {
                 let id: u64 = row.get(0)?;
                 Ok(id)
@@ -204,7 +204,7 @@ pub mod habits {
             .filter(|id| *id != u64::MAX)
             .collect::<Vec<u64>>();
 
-        if habits.is_empty() {
+        if all_habits.is_empty() {
             return Ok(());
         }
 
@@ -228,7 +228,7 @@ pub mod habits {
             .collect::<HashSet<u64>>();
 
         // Check if all habit_ids are in the set.
-        habits.into_iter().for_each(|id| {
+        all_habits.into_iter().for_each(|id| {
             // If a habit_id is not: set the corresponding habit's streak to 0.
             if !yesterdays_habits.contains(&id) {
                 match conn.execute("UPDATE habits SET streak=0 WHERE id=(?id)", params![id]) {

--- a/src-tauri/src/db/init.rs
+++ b/src-tauri/src/db/init.rs
@@ -1,47 +1,55 @@
-use std::{fs, path::Path, sync::{Arc, Mutex}};
-use chrono::Local;
-use rusqlite::{Connection, params, Result as SQLiteResult};
-
-use crate::db::todos::commands::ROOT_GROUP as TODO_ROOT_GROUP;
+use rusqlite::Connection;
+use std::sync::{Arc, Mutex};
 
 pub type DbConn = Arc<Mutex<Connection>>;
 
-pub fn init(path: &str) -> Connection {
-    if !db_exists(path) {
-        create_db(path);
+pub mod db {
+    use super::*;
+    use std::{fs, path::Path};
+
+    pub fn init(path: &str) -> Connection {
+        if !db_exists(path) {
+            create_db(path);
+        }
+
+        // TODO conditional path for diff OS
+        let db_name = format!("{path}/database.sqlite");
+
+        match Connection::open(db_name) {
+            Ok(conn) => conn,
+            Err(e) => panic!("[ERROR] {e}"),
+        }
     }
 
-    // TODO conditional path for diff OS
-    let db_name = format!("{path}/database.sqlite");
+    // Creation functions.
+    fn db_exists(path: &str) -> bool {
+        Path::new(path).exists()
+    }
 
-    match Connection::open(db_name) {
-        Ok(conn) => conn,
-        Err(e) => panic!("[ERROR] {e}"),
+    fn create_db(path: &str) {
+        let db_dir = Path::new(&path).parent().unwrap();
+
+        // If the parent directory does not exist, create it.
+        if !db_dir.exists() {
+            fs::create_dir_all(db_dir).unwrap();
+        }
+
+        // Create the database file.
+        fs::File::create(path).unwrap();
     }
 }
 
-// Creation functions.
-fn db_exists(path: &str) -> bool {
-    Path::new(path).exists()
-}
+pub mod todos {
+    use super::Connection;
+    use crate::db::todos::commands::ROOT_GROUP as TODO_ROOT_GROUP;
+    use chrono::Local;
+    use rusqlite::{params, Result as SQLiteResult};
 
-fn create_db(path: &str) {
-    let db_dir = Path::new(&path).parent().unwrap();
-
-    // If the parent directory does not exist, create it.
-    if !db_dir.exists() {
-        fs::create_dir_all(db_dir).unwrap();
-    }
-
-    // Create the database file.
-    fs::File::create(path).unwrap();
-}
-
-// Setup functions (to be called in main.rs).
-pub fn create_tables(conn: &Connection) -> SQLiteResult<()> {
-    // TODAY
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS today (
+    // Setup functions (to be called in main.rs).
+    pub fn create_tables(conn: &Connection) -> SQLiteResult<()> {
+        // TODAY
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS today (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL,
             type TEXT NOT NULL,
@@ -49,95 +57,91 @@ pub fn create_tables(conn: &Connection) -> SQLiteResult<()> {
             parent_group_id INTEGER,
             created_at DATE DEFAULT (datetime('now','localtime')) NOT NULL
         )",
-        [],
-    )?;
-    // Only add the root group when the table is created for the first time.
-    conn.execute(
+            [],
+        )?;
+        // Only add the root group when the table is created for the first time.
+        conn.execute(
             &format!("INSERT INTO today (id, name, type) VALUES (0, '{TODO_ROOT_GROUP}', 'TaskGroup') ON CONFLICT DO NOTHING"),
             [],
         )?;
 
-    // TOMORROW.
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS tomorrow (
+        // TOMORROW.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS tomorrow (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL,
             type TEXT NOT NULL,
             is_active INTEGER,
             parent_group_id INTEGER
         )",
-        [],
-    )?;
-    // Only add the root group when the table is created for the first time.
-    conn.execute(
+            [],
+        )?;
+        // Only add the root group when the table is created for the first time.
+        conn.execute(
             &format!("INSERT INTO tomorrow (id, name, type) VALUES (0, '{TODO_ROOT_GROUP}', 'TaskGroup') ON CONFLICT DO NOTHING"),
             [],
         )?;
 
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS migration_log (
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS migration_log (
                 date TEXT PRIMARY KEY
             )",
-        [],
-    )?;
+            [],
+        )?;
 
-    Ok(())
-}
+        Ok(())
+    }
 
-pub fn migrate_todos(conn: &Connection) -> SQLiteResult<()> {
-    let today = Local::now().naive_local().date();
+    pub fn migrate_todos(conn: &Connection) -> SQLiteResult<()> {
+        let today = Local::now().naive_local().date();
 
-    let last_migration_date: Option<String> =
-        match conn
-            .query_row("SELECT MAX(date) FROM migration_log", [], |row| row.get(0))
-        {
-            Ok(latest_date) => latest_date,
-            Err(err) => panic!("{err}"),
-        };
-
-    if last_migration_date != Some(today.to_string()) {
-        // Delete completed tasks from today.
-        conn
-            .execute("DELETE FROM today WHERE is_active=0", [])?;
-
-        let max_id: Option<i64> =
-            match conn
-                .query_row("SELECT MAX(id) from today", [], |row| row.get(0))
-            {
-                Ok(val) => val,
+        let last_migration_date: Option<String> =
+            match conn.query_row("SELECT MAX(date) FROM migration_log", [], |row| row.get(0)) {
+                Ok(latest_date) => latest_date,
                 Err(err) => panic!("{err}"),
             };
 
-        // Update ids of all tasks in tomorrow so that uniqueness is maintained.
-        conn.execute(
-            "UPDATE tomorrow SET id=id+(?1) WHERE id!=0",
-            params![max_id],
-        )?;
+        if last_migration_date != Some(today.to_string()) {
+            // Delete completed tasks from today.
+            conn.execute("DELETE FROM today WHERE is_active=0", [])?;
 
-        // Update parent_group_ids of all migrated rows.
-        conn.execute(
-            "UPDATE tomorrow SET parent_group_id=parent_group_id+(?1) WHERE parent_group_id!=0",
-            params![max_id],
-        )?;
+            let max_id: Option<i64> =
+                match conn.query_row("SELECT MAX(id) from today", [], |row| row.get(0)) {
+                    Ok(val) => val,
+                    Err(err) => panic!("{err}"),
+                };
 
-        // Migrate tasks
-        conn.execute(
+            // Update ids of all tasks in tomorrow so that uniqueness is maintained.
+            conn.execute(
+                "UPDATE tomorrow SET id=id+(?1) WHERE id!=0",
+                params![max_id],
+            )?;
+
+            // Update parent_group_ids of all migrated rows.
+            conn.execute(
+                "UPDATE tomorrow SET parent_group_id=parent_group_id+(?1) WHERE parent_group_id!=0",
+                params![max_id],
+            )?;
+
+            // Migrate tasks
+            conn.execute(
                     &format!("INSERT INTO today (id, name, type, is_active, parent_group_id)
                 SELECT id, name, type, is_active, parent_group_id FROM tomorrow WHERE name!='{TODO_ROOT_GROUP}'"),
                     [],
                 )?;
 
-        // Clear tomorrow's tasks
+            // Clear tomorrow's tasks
+            conn.execute(
+                &format!("DELETE FROM tomorrow WHERE name!='{TODO_ROOT_GROUP}'"),
+                [],
+            )?;
+        }
+        // Log the migration
         conn.execute(
-            &format!("DELETE FROM tomorrow WHERE name!='{TODO_ROOT_GROUP}'"),
-            [],
+            "INSERT INTO migration_log (date) VALUES (?1) ON CONFLICT DO NOTHING",
+            params![today.to_string()],
         )?;
-    }
-    // Log the migration
-    conn.execute(
-        "INSERT INTO migration_log (date) VALUES (?1) ON CONFLICT DO NOTHING",
-        params![today.to_string()],
-    )?;
 
-    Ok(())
+        Ok(())
+    }
 }

--- a/src-tauri/src/db/init.rs
+++ b/src-tauri/src/db/init.rs
@@ -55,7 +55,9 @@ pub mod todos {
             type TEXT NOT NULL,
             is_active INTEGER,
             parent_group_id INTEGER,
-            created_at DATE DEFAULT (datetime('now','localtime')) NOT NULL
+            habit_id INTEGER,
+            created_at DATE DEFAULT (datetime('now','localtime')) NOT NULL,
+            FOREIGN KEY(habit_id) REFERENCES habits(id)
         )",
             [],
         )?;

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,2 +1,3 @@
 pub mod init;
 pub mod todos;
+pub mod habits;

--- a/src-tauri/src/db/todos.rs
+++ b/src-tauri/src/db/todos.rs
@@ -1,3 +1,9 @@
+/*
+    If somehow, the number of tasks created by the user crosses (2^32 - 1), my program will crash and burn the entire planet.
+    This is because SQLite stores ROWID as a signed 64 bit integer. But I have OCD and decided to convert the i64 to u64 because
+    IDs cannot be negative.
+*/
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,7 +90,7 @@ pub mod commands {
         name: &str,
         parent_group_id: u64,
         todo_type: Type,
-    ) -> i64 {
+    ) -> u64 {
         let db_conn = conn.lock().unwrap();
 
         let command = format!(
@@ -109,7 +115,7 @@ pub mod commands {
                 "[ERROR] Error occurred while trying to insert item: {}",
                 err.to_string()
             ),
-            Ok(id) => id,
+            Ok(id) => id as u64,
         }
     }
 

--- a/src-tauri/src/db/todos.rs
+++ b/src-tauri/src/db/todos.rs
@@ -161,7 +161,7 @@ pub mod commands {
         }
     }
 
-    /* -------------------------------- Helper Functions -------------------------------- */
+    /* ------------------------------------ Helper Functions ------------------------------------ */
 
     pub fn fetch_todos(conn: &Connection, table: &str, by: FetchBasis) -> SQLiteResult<Vec<Todo>> {
         let mut stmt = match by {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,7 +5,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use habtrack::{db::init, db::todos, window, export};
+use habtrack::{db::init, db::todos, db::habits, window, export};
 use tauri::Manager;
 
 // Start work on database.
@@ -36,6 +36,12 @@ fn main() {
             todos::commands::add_todo,
             todos::commands::delete_todo,
             todos::commands::update_todo,
+            habits::commands::add_habit,
+            habits::commands::add_day_type,
+            habits::commands::fetch_habits,
+            habits::commands::increment_streak,
+            habits::commands::delete_day_type,
+            habits::commands::delete_habit,
             window::open_tomorrow_window,
             window::close_tomorrow_window,
             export::export_to_pdf,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,6 +24,8 @@ fn main() {
             let conn = init::db::init(&db_path);
             init::todos::create_tables(&conn).unwrap();
             init::todos::migrate_todos(&conn).unwrap();
+            init::habits::create_tables(&conn).unwrap();
+            init::habits::validate_streaks(&conn).unwrap();
 
             app.manage(Arc::new(Mutex::new(conn)));
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,11 +8,6 @@ use std::sync::{Arc, Mutex};
 use habtrack::{db::init, db::todos, db::habits, window, export};
 use tauri::Manager;
 
-// Start work on database.
-// TODO: Once done, merge with main, and pull changes into FEATURE-add-delete-task.
-
-
-
 fn main() {
     tauri::Builder::default()
         .setup(|app| {
@@ -42,6 +37,8 @@ fn main() {
             habits::commands::increment_streak,
             habits::commands::delete_day_type,
             habits::commands::delete_habit,
+            habits::commands::fetch_history,
+            habits::commands::create_habit_todo,
             window::open_tomorrow_window,
             window::close_tomorrow_window,
             export::export_to_pdf,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,9 +21,9 @@ fn main() {
                 None => panic!("[ERROR] Cannot find data directory on this device!"),
             };
 
-            let conn = init::init(&db_path);
-            init::create_tables(&conn).unwrap();
-            init::migrate_todos(&conn).unwrap();
+            let conn = init::db::init(&db_path);
+            init::todos::create_tables(&conn).unwrap();
+            init::todos::migrate_todos(&conn).unwrap();
 
             app.manage(Arc::new(Mutex::new(conn)));
 

--- a/src/components/CompletedTasksModal.jsx
+++ b/src/components/CompletedTasksModal.jsx
@@ -41,10 +41,14 @@ const CompletedTasksModal = ({ onChangeTasksView, onCancel }) => {
 
   const onUndo = (item) => {
     // Update db.
+    // Even if a task connected to a habit is undone and redone, the streak will increment only once thanks to CompMap :)
     invoke(TAURI_UPDATE_ITEM, {
       table: TODAY,
       id: item.id,
       field: { Status: false },
+      h_plus_dt: item.habit_id
+        ? [item.habit_id, item.dt_id]
+        : [null, null],
     });
 
     // Update frontend of completed tasks view.
@@ -87,13 +91,14 @@ const CompletedTasksModal = ({ onChangeTasksView, onCancel }) => {
                   <li key={node.id}>
                     <div className="completed-task">
                       <label>{node.name}</label>
-                      <button
+                      {/* Only allow tasks not corresponding to habits to be undone. */}
+                      {node.habit_id === null && <button
                         type="button"
                         className="task-btn"
                         onClick={() => onUndo(node)}
                       >
                         <Undo />
-                      </button>
+                      </button>}
                     </div>
                   </li>
                 );

--- a/src/views/HabitsView/HabitsView.jsx
+++ b/src/views/HabitsView/HabitsView.jsx
@@ -2,12 +2,14 @@ import React from "react";
 import Navbar from "./Navbar3";
 import Habits from "./Habits";
 
+// TODO wtf is HabitsGroup? uh... update the frontend of TasksView if tasks are created for habits.
+
 const HabitsView = () => {
   return (
     <div className="box">
-        <Navbar />
+      <Navbar />
 
-        < Habits />
+      <Habits />
     </div>
   );
 };

--- a/src/views/TasksView/DragDropContext.jsx
+++ b/src/views/TasksView/DragDropContext.jsx
@@ -40,6 +40,7 @@ const DragDropProvider = ({ children, item, dbTable }) => {
       table: dbTable,
       id: droppedItemId,
       field: { Parent: targetId },
+      h_plus_dt: [null, null],
     });
 
     setStructure(() => {

--- a/src/views/TasksView/Task.jsx
+++ b/src/views/TasksView/Task.jsx
@@ -62,7 +62,7 @@ const Task = (props) => {
     invoke(TAURI_DELETE_ITEM, {
       table: props.dbTable,
       id: props.id,
-      todo_type: {type: TASK},
+      todo_type: { type: TASK },
     });
 
     // Delete task from the frontend.
@@ -87,6 +87,7 @@ const Task = (props) => {
       table: props.dbTable,
       id: props.id,
       field: { Name: editedName },
+      h_plus_dt: [null, null],
     });
 
     // Update name on the frontend.
@@ -122,10 +123,14 @@ const Task = (props) => {
       table: props.dbTable,
       id: props.id,
       field: { Status: true },
+      h_plus_dt: props.habit_id
+        ? [props.habit_id, props.dt_id]
+        : [null, null],
     });
 
     // Update frontend.
     updateFrontend(removeItem, view, props.onChangeView, props.id);
+    // TODO update the frontend of HabitsView here as well.
   }
   const scroll = useCallback(
     (container, direction) => {

--- a/src/views/TasksView/TaskGroup.jsx
+++ b/src/views/TasksView/TaskGroup.jsx
@@ -83,6 +83,7 @@ const TaskGroup = ({
       table: dbTable,
       id: id,
       field: { Name: editedName },
+      h_plus_dt: [null, null],
     });
 
     // Update name on the frontend.
@@ -218,6 +219,9 @@ const TaskGroup = ({
                   onChangeView={onChangeView}
                   dbTable={dbTable}
                   taskViewRef={taskViewRef}
+                  // TODO Change this when habits is finally implemented.
+                  habit_id={null}
+                  dt_id={null}
                 />
               );
             } else if (child.type === TASK_GROUP) {


### PR DESCRIPTION
# API
1. `fn add_habit(name: str, day_types: [(str, str)]) -> (int, map<str, (int, str)>)`:  
	- input:
		1. name of the habit.
		2. an array of tuples containing the name and color associated to day types.
	- output: a tuple containing the id of newly created habit, and a mapping of day types to their ids.

2. `fn add_day_type(habit_id: int, dt_name: str, color: str) -> int`:
	- input:
		1. the id of the habit you want to a day type to.
		2. the name of the day type.
		3. its color.
	- output: the id of the new created day type.

3. `fn fetch_habits() -> str`:
	- output: all the habits in JSON format, inside an array.

4. `fn increment_streak(habit_id: int, dt_id: int)`:
	- input:
		1. the id of the habit completed.
		2. the day type id of today's completion.
	- NOTE: While this command does update the highest_streak of the habit if the current streak surpasses it, it does not update it in the front-end.

5. `fn delete_day_type(habit_id: int, how_many: Object)`:
	- input:
		1. the id of the day type you want to delete.
		2. there are two types of objects that are acceptable inputs to the `how_many` parameter:
			1. `{to_delete: {One: dt_id}}`: You want to delete one day type and its id is `dt_id`.
			2. `{to_delete: 'All'}`: You want to delete all day types.

6. `fn delete_habit(habit_id: u64)`:
	- input: the id of the habit you want to delete.